### PR TITLE
Enhanced mobile experience

### DIFF
--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -12,7 +12,7 @@
     <body>
         <div id="primer-spec-top"></div>
         <!-- Custom sidebar with a table of content -->
-        <div class="primer-spec-sidebar no-print">
+        <div class="primer-spec-sidebar position-fixed top-0 py-5 no-print">
             <h2 class="primer-spec-toc-ignore">Contents</h2>
             <br>
             <div id="primer-spec-toc"></div>
@@ -24,7 +24,7 @@
         </a>
         
         <!-- Actual content -->
-        <div class="container-lg px-3 my-5 markdown-body primer-spec-content-with-sidebar">
+        <div class="container-lg px-3 my-5 markdown-body primer-spec-content-margin-extra">
             {% if site.title and site.title != page.title %}
             <h1 class="primer-spec-toc-ignore"><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1>
             {% endif %}
@@ -57,7 +57,11 @@
         <script src="assets/js/html-table-of-contents.js"></script>
         <script>
             function isSmallScreen() {
-                return screen.width < 900;
+                var _width = Math.max(
+                    document.documentElement.clientWidth,
+                    window.innerWidth || 0
+                );
+                return _width < 900;
             }
 
 
@@ -75,8 +79,8 @@
                     if (sidebar_is_shown) {
                         $('.primer-spec-sidebar').css('display', 'none');
                         $('.markdown-body')
-                            .removeClass('primer-spec-content-with-sidebar')
-                            .addClass('primer-spec-content-without-sidebar');
+                            .removeClass('primer-spec-content-margin-extra')
+                            .addClass('primer-spec-content-margin-auto');
                         $('.primer-spec-sidebar-toggle > .fas')
                             .removeClass('fa-caret-left')
                             .addClass('fa-caret-right');
@@ -84,9 +88,20 @@
                     }
                     else {
                         $('.primer-spec-sidebar').css('display', 'inherit');
-                        $('.markdown-body')
-                            .removeClass('primer-spec-content-without-sidebar')
-                            .addClass('primer-spec-content-with-sidebar');
+                        if (!isSmallScreen()) {
+                            // On small screens, changing the margin causes the
+                            // content wrapping to change. 
+                            // Fow example, when a user clicks a link to a
+                            // section in the sidebar on mobile and then
+                            // collapses the sidebar, the content would shift
+                            // and the user would not know where they are on the
+                            // page.
+                            // To avoid this, we do not change the margin of the
+                            // content on small screens.
+                            $('.markdown-body')
+                                .removeClass('primer-spec-content-margin-auto')
+                                .addClass('primer-spec-content-margin-extra');
+                        }
                         $('.primer-spec-sidebar-toggle > .fas')
                             .removeClass('fa-caret-right')
                             .addClass('fa-caret-left');

--- a/_sass/spec/index.scss
+++ b/_sass/spec/index.scss
@@ -6,16 +6,15 @@
 }
 
 .primer-spec-sidebar {
-    position: fixed; 
-    top: 0px;
     width: 15em;
     margin-left: 1em;
     height: 100%;
-
-    padding-top: 2em;
-    padding-bottom: 2em;
     overflow: scroll;
     border-right: 1px solid lightgrey;
+
+    // Need to set a background color because the sidebar overlays on top of
+    // the content. (By default, the element has a transparent background.
+    background-color: white;
 }
 
 .primer-spec-sidebar-toggle {
@@ -29,15 +28,17 @@
     }
 }
 
-.primer-spec-content {
-    &-with-sidebar {
+.primer-spec-content-margin {
+    &-extra {
         // When the sidebar is shown, this ensures that the body of the page
         // does not overlap with the sidebar.
+        // This is not done on small screens, because the sidebar overlays
+        // on top of the content.
         margin-left: 15.5em;
     }
-    &-without-sidebar {
-        // When the sidebar is shown, this ensures that the body of the page
-        // stays centered like the default theme.
+    &-auto {
+        // When the sidebar is not shown, this ensures that the body of the
+        // page stays centered like the default theme.
         margin-left: auto;
     }
 }


### PR DESCRIPTION
The current spec theme is not mobile-friendly. When the sidebar opens, the content width changes — this means that when a user clicks a link in the sidebar and then hides the sidebar, the content of the page shifts, leaving the user confused about where they are in the document. (You can try this on mobile on one of the current specs.)

This PR makes the sidebar overlays on top of the content on small screens, so that the position of the content doesn't change every time the sidebar is toggled.

Also modified the layout to use GitHub Primer CSS utility classes instead of defining them separately in `spec/index.scss`.