### PR TITLE
[Feature] Theme Support (and better UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 
 Primer Spec is built on top of the wonderful [Primer theme](https://github.com/pages-themes/primer), and adds functionality useful for pages with a lot of content. This theme was primarily designed for hosting Project specifications for EECS courses at the University of Michigan.
 
+## Contents
+- [Integrating with GitHub Pages](#integrating-with-github-pages)
+- [Previewing locally](#previewing-locally)
+  - [Part 1: Create the dependency files](#local-setup-part-1-create-the-dependency-files)
+  - [Part 2: Install the dependencies](#local-setup-part-2-install-the-dependencies)
+- [Customization](#customization)
+- [Contributing](#contributing)
+  - [Typical workflow](#typical-workflow)
+  - [Bootstrap your local environment](#bootstrap-your-local-environment)
+  - [Run tests](#run-tests)
+  - [Modifications from Primer](#modifications-from-primer)
+  - [Adding new subthemes](#adding-new-subthemes)
+- [Keeping this theme up-to-date with Primer](#keeping-this-theme-up-to-date-with-primer)
+
 ## Integrating with GitHub Pages
 
 To use the Primer Spec theme:
@@ -175,7 +189,7 @@ Interested in contributing to Primer? We'd love your help. Primer is an open sou
 
 3. Run `script/server` to begin the Jekyll server. By default, the site is served at http://localhost:4000/. (It monitors changes you make to most theme files and automatically rebuilds the website.)
 
-### Running tests
+### Run tests
 
 The theme contains a minimal test suite, to ensure a site with the theme would build successfully. To run the tests, simply run `script/cibuild`. You'll need to run `script/bootstrap` one before the test script will work.
 
@@ -183,13 +197,23 @@ The theme contains a minimal test suite, to ensure a site with the theme would b
 
 Here are key changes made to the original Primer theme to add a sidebar:
 
-- Created `_layouts/spec.html`. This file is used to render MarkDown files with `layout: spec` at the top. The file is similar to `_layouts/default.html`, but adds the sidebar and references the JavaScript needed to render the table of contents.
+- Created `_layouts/spec.html`. This file is used to render MarkDown files with `layout: spec` at the top. The file is similar to `_layouts/default.html`, but adds the sidebar and references the JavaScript needed to render the table of contents. HTML comments in `spec.html` indicate sections of the layout that have been modified from `default.html`.
 
-- Created `_sass/spec/` with the SCSS files needed to display the sidebar. Also modified `_sass/jekyll-theme-primer.scss` to include these files.
+- Created `_sass/spec/` with the SCSS files needed to display the sidebar. Also created stylesheets in `assets/css` to include these files.
 
-- Created `assets/js/` with the necessary files to generate a table of contents.
+- Created `assets/js/` with the necessary scripts to generate a table of contents.
 
-### Keeping this theme up-to-date with Primer
+### Adding new subthemes
+
+Primer spec allows website visitors to change the appearance of the website by selecting from built-in subthemes. The stylesheets for these subthemes are defined in `_sass/spec`, and are typically named as `<name>.theme.scss`.
+
+To create a new subtheme:
+- Create the file `_sass/spec/<name>.theme.scss`. Take inspiration from the structure of other subtheme stylesheets.
+- Create the file `assets/css/theme_<name>.scss`. Follow the structure of other stylesheets in the same directory to import the theme stylesheet from the `_sass/spec` directory.
+- Modify the list of subthemes in `_layouts/spec.html`. The list is defined in the `_available_subthemes` function inside the custom scripts on the page.
+- Ensure that your changes work well on mobile! Use browser developer tools to verify this before creating a Pull Request on GitHub.
+
+## Keeping this theme up-to-date with Primer
 
 It's important to periodically check for changes from the [original upstream theme (Primer)](https://github.com/pages-themes/primer).
 

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
 {% seo %}
-        <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+        <link rel="stylesheet" href="{{ "/assets/css/theme_default.css?v=" | append: site.github.build_revision | relative_url }}">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
     </head>
     <body>
@@ -19,8 +19,8 @@
         </div> <!-- .primer-spec-sidebar -->
 
         <!-- Show/Hide Sidebar button -->
-        <a href="#primer-spec-top" class="primer-spec-sidebar-toggle no-print">
-            <i class="fas fa-caret-left"></i>
+        <a href="#primer-spec-top" class="primer-spec-sidebar-toggle primer-spec-sidebar-toggle-fixed-to-page no-print">
+            <i class="fas fa-bars"></i>
         </a>
         
         <!-- Actual content -->
@@ -81,10 +81,6 @@
                         $('.markdown-body')
                             .removeClass('primer-spec-content-margin-extra')
                             .addClass('primer-spec-content-margin-auto');
-                        $('.primer-spec-sidebar-toggle > .fas')
-                            .removeClass('fa-caret-left')
-                            .addClass('fa-caret-right');
-                        $('.primer-spec-sidebar-toggle').css('left', '0.1em');
                     }
                     else {
                         $('.primer-spec-sidebar').css('display', 'inherit');
@@ -102,10 +98,6 @@
                                 .removeClass('primer-spec-content-margin-auto')
                                 .addClass('primer-spec-content-margin-extra');
                         }
-                        $('.primer-spec-sidebar-toggle > .fas')
-                            .removeClass('fa-caret-right')
-                            .addClass('fa-caret-left');
-                        $('.primer-spec-sidebar-toggle').css('left', '5em');
                     }
                     sidebar_is_shown = !sidebar_is_shown;
                     return false;

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -19,18 +19,25 @@
         <div class="primer-spec-sidebar position-fixed top-0 py-5 no-print">
             <h2 class="primer-spec-toc-ignore">
                 Contents
-                <a href="#primer-spec-top" class="primer-spec-settings-toggle primer-spec-hoverable">
-                    <i class="fas fa-cog"></i>
+                <!-- Show/Hide Sidebar button -->
+                <a href="#primer-spec-top" class="primer-spec-sidebar-toggle primer-spec-hoverable sidebar-shown no-print">
+                    <i class="fas fa-bars"></i>
                 </a>
             </h2>
             <br>
             <div id="primer-spec-toc"></div>
         </div> <!-- .primer-spec-sidebar -->
 
-        <!-- Show/Hide Sidebar button -->
-        <a href="#primer-spec-top" class="primer-spec-sidebar-toggle primer-spec-hoverable primer-spec-hoverable-fixed-to-page no-print">
-            <i class="fas fa-bars"></i>
-        </a>
+        <div class="primer-spec-topbar position-fixed width-full top-0 left-0 py-2 no-print">
+            <!-- Show/Hide Sidebar button -->
+            <a href="#primer-spec-top" class="primer-spec-sidebar-toggle primer-spec-sidebar-toggle-fixed primer-spec-hoverable primer-spec-float-left sidebar-shown no-print">
+                <i class="fas fa-bars"></i>
+            </a>
+            <!-- Show Settings button -->
+            <a href="#primer-spec-top" class="primer-spec-settings-toggle primer-spec-hoverable primer-spec-float-right no-print">
+                <i class="fas fa-cog"></i>
+            </a>
+        </div>
 
         <!--
             Settings modal. Treat it exactly like the actual content, but its
@@ -38,13 +45,17 @@
             It should be displayed when the "settings" icon is clicked.
         -->
         <div class="primer-spec-settings container-lg markdown-body primer-spec-content-margin-extra px-3 py-5 position-fixed top-0 left-0" hidden>
+            <div class="primer-spec-topbar position-fixed width-full top-0 left-0 py-2 no-print">
+                <!-- Hide Settings buttong -->
+                <a href="#primer-spec-top" class="primer-spec-settings-toggle primer-spec-hoverable primer-spec-float-right no-print">
+                    <i class="fas fa-times"></i>
+                </a>
+            </div>
             <h1 class="primer-spec-toc-ignore">Spec Theme Settings</h1>
             <p>Choose your theme!</p>
             <select class="primer-spec-subtheme-selector">
             </select>
-            <a href="#primer-spec-top" class="primer-spec-settings-toggle primer-spec-hoverable primer-spec-hoverable-fixed-to-page">
-                <i class="fas fa-times"></i>
-            </a>
+            
         </div>
 
         <!-- END CUSTOM SPEC CODE -->
@@ -105,6 +116,7 @@
                     sidebar: $('.primer-spec-sidebar'),
                     main_content: $('.markdown-body'),
                     sidebar_toggle_buttons: $('.primer-spec-sidebar-toggle'),
+                    topbar: $('.primer-spec-topbar'),
                     headings: $('h1, h2, h3, h4, h5, h6'),
 
                     subtheme_selector_dropdown: $('select.primer-spec-subtheme-selector'),
@@ -130,12 +142,14 @@
                 function toggleSidebar() {
                     if (sidebar_is_shown) {
                         $NODES.sidebar.css('display', 'none');
+                        $NODES.sidebar_toggle_buttons.removeClass('sidebar-shown');
                         $NODES.main_content
                             .removeClass('primer-spec-content-margin-extra')
                             .addClass('primer-spec-content-margin-auto');
                     }
                     else {
                         $NODES.sidebar.css('display', 'inherit');
+                        $NODES.sidebar_toggle_buttons.addClass('sidebar-shown');
                         if (!isSmallScreen()) {
                             // On small screens, changing the margin causes the
                             // content wrapping to change.
@@ -156,9 +170,14 @@
                 }
                 $NODES.sidebar_toggle_buttons.on('click', toggleSidebar);
 
-                // If this is a mobile browser, don't display the TOC.
                 if (isSmallScreen()) {
+                    // If this is a mobile browser, don't display the TOC.
                     toggleSidebar();
+                    // Also push the main content to make room for the topbar.
+                    $NODES.main_content.addClass('primer-spec-content-mobile');
+                    // Finally, add a background color to the topbar to make it
+                    // opaque.
+                    $NODES.topbar.addClass('primer-spec-topbar-mobile');
                 }
 
 

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -259,7 +259,8 @@
                     return {
                         'default': "{{ "/assets/css/theme_default.css?v=" | append: site.github.build_revision | relative_url }}",
                         'bella': "{{ "/assets/css/theme_bella.css?v=" | append: site.github.build_revision | relative_url }}",
-                        'modern': "{{ "/assets/css/theme_metro.css?v=" | append: site.github.build_revision | relative_url }}"
+                        'modern': "{{ "/assets/css/theme_metro.css?v=" | append: site.github.build_revision | relative_url }}",
+                        'xcode-dark': "{{ "/assets/css/theme_xcode-dark.css?v=" | append: site.github.build_revision | relative_url }}"
                     };
                 }
                 var current_subtheme = 'default';

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -184,43 +184,6 @@
 
 
                 /**
-                 * SIDEBAR: Hide in print preview
-                 */
-
-                // When students print the spec, the sidebar shouldn't show up.
-                // Despite trying to do this with CSS, the JS solution ends up
-                // printing with the proper margins.
-                var should_undo_toggle = false;
-                var beforePrint = function() {
-                    if (sidebar_is_shown){
-                        should_undo_toggle = true;
-                        toggleSidebar();
-                    }
-                };
-                var afterPrint = function() {
-                    if (should_undo_toggle) {
-                        should_undo_toggle = false;
-                        toggleSidebar();
-                    }
-                };
-                // Safari doesn't support onbeforeprint, etc.
-                // So this is the "official" work-around for webkit.
-                if (window.matchMedia) {
-                    var mediaQueryList = window.matchMedia('print');
-                    mediaQueryList.addListener(function(mql) {
-                        if (mql.matches) {
-                            beforePrint();
-                        } else {
-                            afterPrint();
-                        }
-                    });
-                }
-                // But most other browsers support this.
-                window.onbeforeprint = beforePrint;
-                window.onafterprint = afterPrint;
-
-
-                /**
                  * TOPBAR & Internal Links: Display on mobile, change offset
                  * when clicking sidebar links.
                  */
@@ -324,10 +287,10 @@
                  * SUBTHEME SETTINGS
                  */
 
-                var settings_shown = false;
+                var settings_is_shown = false;
                 function toggleSettings() {
-                    $NODES.subtheme_settings_pane.attr('hidden', settings_shown);
-                    settings_shown = !settings_shown;
+                    $NODES.subtheme_settings_pane.attr('hidden', settings_is_shown);
+                    settings_is_shown = !settings_is_shown;
                     return false;
                 }
                 $NODES.subtheme_settings_toggle_buttons
@@ -378,6 +341,52 @@
                         window.localStorage.setItem(storage_subtheme_key, subtheme_name);
                     }
                 }
+
+
+                /**
+                 * PRINT PREVIEW: Hide sidebar and settings in print preview.
+                 */
+
+                // When students print the spec, the sidebar shouldn't show up.
+                // Despite trying to do this with CSS, the JS solution ends up
+                // printing with the proper margins.
+                var should_undo_sidebar_toggle = false;
+                var should_undo_settings_toggle = false;
+                var beforePrint = function() {
+                    if (sidebar_is_shown){
+                        should_undo_sidebar_toggle = true;
+                        toggleSidebar();
+                    }
+                    if (settings_is_shown) {
+                        should_undo_settings_toggle = true;
+                        toggleSettings();
+                    }
+                };
+                var afterPrint = function() {
+                    if (should_undo_sidebar_toggle) {
+                        should_undo_sidebar_toggle = false;
+                        toggleSidebar();
+                    }
+                    if (should_undo_settings_toggle) {
+                        should_undo_settings_toggle = false;
+                        toggleSettings();
+                    }
+                };
+                // Safari doesn't support onbeforeprint, etc.
+                // So this is the "official" work-around for webkit.
+                if (window.matchMedia) {
+                    var mediaQueryList = window.matchMedia('print');
+                    mediaQueryList.addListener(function(mql) {
+                        if (mql.matches) {
+                            beforePrint();
+                        } else {
+                            afterPrint();
+                        }
+                    });
+                }
+                // But most other browsers support this.
+                window.onbeforeprint = beforePrint;
+                window.onafterprint = afterPrint;
             })();
         </script>
         <!-- END CUSTOM SPEC CODE -->

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -42,9 +42,9 @@
             <p>Choose your theme!</p>
             <select class="primer-spec-subtheme-selector">
             </select>
-            <a href="#" class="primer-spec-settings-toggle primer-spec-hoverable primer-spec-hoverable-fixed-to-page">
+            <a href="#primer-spec-top" class="primer-spec-settings-toggle primer-spec-hoverable primer-spec-hoverable-fixed-to-page">
                 <i class="fas fa-times"></i>
-            </button>
+            </a>
         </div>
 
         <!-- END CUSTOM SPEC CODE -->

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -46,15 +46,22 @@
         -->
         <div class="primer-spec-settings container-lg markdown-body primer-spec-content-margin-extra px-3 py-5 position-fixed top-0 left-0" hidden>
             <div class="primer-spec-topbar position-fixed width-full top-0 left-0 py-2 no-print">
-                <!-- Hide Settings buttong -->
+                <!-- Hide Settings button -->
                 <a href="#primer-spec-top" class="primer-spec-settings-toggle primer-spec-hoverable primer-spec-float-right no-print">
                     <i class="fas fa-times"></i>
                 </a>
             </div>
+
             <h1 class="primer-spec-toc-ignore">Spec Theme Settings</h1>
             <p>Choose your theme!</p>
             <select class="primer-spec-subtheme-selector">
             </select>
+
+            <hr>
+
+            <p><small>
+                Does the spec display incorrectly? <a href="https://github.com/eecs485staff/primer-spec/issues">Let us know by adding a new "issue" here.</a>
+            </small></p>
             
         </div>
 

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -211,6 +211,15 @@
                                             - internal_link_offset;
                     // Scroll to the scroll_position.
                     $(window).scrollTop(scroll_position);
+                    
+                    // If the settings pane is open, close it.
+                    if (settings_is_shown) {
+                        toggleSettings();
+                    }
+                    // On mobile, close the sidebar and settings.
+                    if (isSmallScreen()) {
+                        toggleSidebar();
+                    }
                     return false;
                 });
 
@@ -223,7 +232,7 @@
                 // sidebar. Based on: https://codepen.io/eksch/pen/xwdOeK
                 $(window).scroll(function() {
                     var scroll_distance = $(window).scrollTop();
-                    var threshold = $(window).height() / 2;
+                    var threshold = internal_link_offset;
                     $NODES.headings
                         .filter(function(i) {
                             return !$(this).hasClass('primer-spec-toc-ignore');

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -28,7 +28,7 @@
         </div> <!-- .primer-spec-sidebar -->
 
         <!-- Show/Hide Sidebar button -->
-        <a href="#primer-spec-top" class="primer-spec-sidebar-toggle primer-spec-sidebar-toggle-fixed-to-page primer-spec-hoverable no-print">
+        <a href="#primer-spec-top" class="primer-spec-sidebar-toggle primer-spec-hoverable primer-spec-hoverable-fixed-to-page no-print">
             <i class="fas fa-bars"></i>
         </a>
 
@@ -42,7 +42,7 @@
             <p>Choose your theme!</p>
             <select class="primer-spec-subtheme-selector">
             </select>
-            <a href="#" class="primer-spec-settings-toggle primer-spec-settings-close-fixed primer-spec-hoverable">
+            <a href="#" class="primer-spec-settings-toggle primer-spec-hoverable primer-spec-hoverable-fixed-to-page">
                 <i class="fas fa-times"></i>
             </button>
         </div>
@@ -81,7 +81,7 @@
             src="https://code.jquery.com/jquery-3.3.1.min.js"
             integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
             crossorigin="anonymous"></script>
-        <script src="assets/js/html-table-of-contents.js"></script>
+        <script src="/assets/js/html-table-of-contents.js"></script>
         <script>
             function isSmallScreen() {
                 var _width = Math.max(

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -286,7 +286,8 @@
                 function _available_subthemes() {
                     return {
                         'default': "{{ "/assets/css/theme_default.css?v=" | append: site.github.build_revision | relative_url }}",
-                        'bella': "{{ "/assets/css/theme_bella.css?v=" | append: site.github.build_revision | relative_url }}"
+                        'bella': "{{ "/assets/css/theme_bella.css?v=" | append: site.github.build_revision | relative_url }}",
+                        'modern': "{{ "/assets/css/theme_metro.css?v=" | append: site.github.build_revision | relative_url }}"
                     };
                 }
                 var current_subtheme = 'default';

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -236,7 +236,17 @@
                         'bella': "{{ "/assets/css/theme_bella.css?v=" | append: site.github.build_revision | relative_url }}"
                     };
                 }
+                var current_subtheme = 'default';
                 var subthemes = _available_subthemes()
+
+                function updateTheme(subtheme_name) {
+                    if (subtheme_name in subthemes) {
+                        current_subtheme = subtheme_name;
+                        $NODES.subtheme_selector_dropdown.val(subtheme_name);
+                        $NODES.subtheme_stylesheet.prop('href', subthemes[subtheme_name]);
+                        updateStorage(subtheme_name);
+                    }
+                }
 
                 Object.keys(subthemes).forEach(function (subtheme_name) {
                     $NODES.subtheme_selector_dropdown.append(
@@ -246,9 +256,13 @@
                     )
                 });
 
+                // The very first time, set the theme to default to ensure the
+                // settings option has the correct initial value.
+                updateTheme(current_subtheme);
+
                 $NODES.subtheme_selector_dropdown.on('change', function () {
                     var chosen_subtheme = $NODES.subtheme_selector_dropdown.val();
-                    $NODES.subtheme_stylesheet.prop('href', subthemes[chosen_subtheme]);
+                    updateTheme(chosen_subtheme);
                 });
 
 
@@ -264,6 +278,52 @@
                 }
                 $NODES.subtheme_settings_toggle_buttons
                   .on('click', toggleSettings);
+
+                
+
+                /**
+                 * SUBTHEME SETTINGS: Retrieve stored values if applicable
+                 */
+
+                function storageAvailable(type) {
+                    var storage;
+                    try {
+                        storage = window[type];
+                        var x = '__storage_test__';
+                        storage.setItem(x, x);
+                        storage.removeItem(x);
+                        return true;
+                    }
+                    catch(e) {
+                        return e instanceof DOMException && (
+                            // everything except Firefox
+                            e.code === 22 ||
+                            // Firefox
+                            e.code === 1014 ||
+                            // test name field too, because code might not be present
+                            // everything except Firefox
+                            e.name === 'QuotaExceededError' ||
+                            // Firefox
+                            e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+                            // acknowledge QuotaExceededError only if there's something already stored
+                            (storage && storage.length !== 0);
+                    }
+                }
+
+                var storage_subtheme_key = 'PRIMER_SPEC_SUBTHEME';
+                if (storageAvailable('localStorage')) {
+                    // Retrieve the old value if applicable
+                    var stored_subtheme = window.localStorage.getItem(storage_subtheme_key);
+                    if (stored_subtheme) {
+                        updateTheme(stored_subtheme);
+                    }
+                }
+
+                function updateStorage(subtheme_name) {
+                    if (storageAvailable('localStorage')) {
+                        window.localStorage.setItem(storage_subtheme_key, subtheme_name);
+                    }
+                }
             })();
         </script>
         <!-- END CUSTOM SPEC CODE -->

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -180,11 +180,6 @@
                 if (isSmallScreen()) {
                     // If this is a mobile browser, don't display the TOC.
                     toggleSidebar();
-                    // Also push the main content to make room for the topbar.
-                    $NODES.main_content.addClass('primer-spec-content-mobile');
-                    // Finally, add a background color to the topbar to make it
-                    // opaque.
-                    $NODES.topbar.addClass('primer-spec-topbar-mobile');
                 }
 
 
@@ -226,13 +221,45 @@
 
 
                 /**
+                 * TOPBAR & Internal Links: Display on mobile, change offset
+                 * when clicking sidebar links.
+                 */
+                
+                // This variable sets the extra offset needed when an internal
+                // link is clicked. (This is because on mobile, the topbar is
+                // opaque, so clicking a link has to make the section appear
+                // underneath the topbar.)
+                var internal_link_offset = 0;
+                if (isSmallScreen()) {
+                    // Push the main content to make room for the topbar.
+                    $NODES.main_content.addClass('primer-spec-content-mobile');
+                    // Add a background color to the topbar to make it
+                    // opaque.
+                    $NODES.topbar.addClass('primer-spec-topbar-mobile');
+                    // Get the topbar's height *including padding*.
+                    internal_link_offset = $NODES.topbar.outerHeight();
+                }
+
+                // When an internal link in the sidebar is clicked,
+                // execute custom code.
+                $('.primer-spec-toc-item > a').on('click', function() {
+                    var $scroll_target = $($(this).attr('href'));
+                    var scroll_position = $scroll_target.offset().top
+                                            - internal_link_offset;
+                    // Scroll to the scroll_position.
+                    $(window).scrollTop(scroll_position);
+                    return false;
+                });
+
+
+                /**
                  * SIDEBAR: Display section location
                  */
 
                 // Spy on where the user has scrolled and display that in the
                 // sidebar. Based on: https://codepen.io/eksch/pen/xwdOeK
                 $(window).scroll(function() {
-                    var scrollDistance = $(window).scrollTop();
+                    var scroll_distance = $(window).scrollTop();
                     var threshold = $(window).height() / 2;
                     $NODES.headings
                         .filter(function(i) {
@@ -244,7 +271,7 @@
                             // activate section items from the top, the last
                             // remaining "active" item is the lowest "active"
                             // section.
-                            if ($(this).position().top - threshold <= scrollDistance) {
+                            if ($(this).position().top - threshold <= scroll_distance) {
                                 $('.primer-spec-toc-item.primer-spec-toc-active').removeClass('primer-spec-toc-active');
                                 $('.primer-spec-toc-item').eq(i).addClass('primer-spec-toc-active');
                             }
@@ -296,10 +323,10 @@
                  * SUBTHEME SETTINGS
                  */
 
-                var settingsShown = false;
+                var settings_shown = false;
                 function toggleSettings() {
-                    $NODES.subtheme_settings_pane.attr('hidden', settingsShown);
-                    settingsShown = !settingsShown;
+                    $NODES.subtheme_settings_pane.attr('hidden', settings_shown);
+                    settings_shown = !settings_shown;
                     return false;
                 }
                 $NODES.subtheme_settings_toggle_buttons

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -6,23 +6,49 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
 {% seo %}
-        <link rel="stylesheet" href="{{ "/assets/css/theme_default.css?v=" | append: site.github.build_revision | relative_url }}">
+        <!-- BEGIN CUSTOM SPEC CODE -->
+        <link rel="stylesheet" id="primer-spec-subtheme-style" href="{{ "/assets/css/theme_default.css?v=" | append: site.github.build_revision | relative_url }}">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
+        <!-- END CUSTOM SPEC CODE -->
     </head>
     <body>
+        <!-- BEGIN CUSTOM SPEC CODE -->
+
         <div id="primer-spec-top"></div>
         <!-- Custom sidebar with a table of content -->
         <div class="primer-spec-sidebar position-fixed top-0 py-5 no-print">
-            <h2 class="primer-spec-toc-ignore">Contents</h2>
+            <h2 class="primer-spec-toc-ignore">
+                Contents
+                <a href="#primer-spec-top" class="primer-spec-settings-toggle primer-spec-hoverable">
+                    <i class="fas fa-cog"></i>
+                </a>
+            </h2>
             <br>
             <div id="primer-spec-toc"></div>
         </div> <!-- .primer-spec-sidebar -->
 
         <!-- Show/Hide Sidebar button -->
-        <a href="#primer-spec-top" class="primer-spec-sidebar-toggle primer-spec-sidebar-toggle-fixed-to-page no-print">
+        <a href="#primer-spec-top" class="primer-spec-sidebar-toggle primer-spec-sidebar-toggle-fixed-to-page primer-spec-hoverable no-print">
             <i class="fas fa-bars"></i>
         </a>
-        
+
+        <!--
+            Settings modal. Treat it exactly like the actual content, but its
+            position on the page is fixed.
+            It should be displayed when the "settings" icon is clicked.
+        -->
+        <div class="primer-spec-settings container-lg markdown-body primer-spec-content-margin-extra px-3 py-5 position-fixed top-0 left-0" hidden>
+            <h1 class="primer-spec-toc-ignore">Spec Theme Settings</h1>
+            <p>Choose your theme!</p>
+            <select class="primer-spec-subtheme-selector">
+            </select>
+            <a href="#" class="primer-spec-settings-toggle primer-spec-settings-close-fixed primer-spec-hoverable">
+                <i class="fas fa-times"></i>
+            </button>
+        </div>
+
+        <!-- END CUSTOM SPEC CODE -->
+
         <!-- Actual content -->
         <div class="container-lg px-3 my-5 markdown-body primer-spec-content-margin-extra">
             {% if site.title and site.title != page.title %}
@@ -50,6 +76,7 @@
             ga('send', 'pageview');
         </script>
         {% endif %}
+        <!-- BEGIN CUSTOM SPEC CODE -->
         <script
             src="https://code.jquery.com/jquery-3.3.1.min.js"
             integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
@@ -65,28 +92,53 @@
             }
 
 
-            // Sidebar stuff
             (function () {
                 // Trivia: This is an Immediately Invoked Function Expression.
                 // The code is lexically scoped, but also runs immediately.
                 // (https://developer.mozilla.org/en-US/docs/Glossary/IIFE)
-                
+
+                /**
+                 * SETUP
+                 */
+
+                var $NODES = {
+                    sidebar: $('.primer-spec-sidebar'),
+                    main_content: $('.markdown-body'),
+                    sidebar_toggle_buttons: $('.primer-spec-sidebar-toggle'),
+                    headings: $('h1, h2, h3, h4, h5, h6'),
+
+                    subtheme_selector_dropdown: $('select.primer-spec-subtheme-selector'),
+                    subtheme_stylesheet: $('#primer-spec-subtheme-style'),
+                    subtheme_settings_pane: $('.primer-spec-settings'),
+                    subtheme_settings_toggle_buttons: $('.primer-spec-settings-toggle'),
+                }
+
+
+                /**
+                 * SIDEBAR: Generate ToC
+                 */
+
+                // Generate the HTML table of contents in the sidebar.
                 htmlTableOfContents();
 
-                // Show/hide the sidebar when appropriate buttons are clicked
+
+                /**
+                 * SIDEBAR: Show/hide when buttons are clicked
+                 */
+
                 var sidebar_is_shown = true;
                 function toggleSidebar() {
                     if (sidebar_is_shown) {
-                        $('.primer-spec-sidebar').css('display', 'none');
-                        $('.markdown-body')
+                        $NODES.sidebar.css('display', 'none');
+                        $NODES.main_content
                             .removeClass('primer-spec-content-margin-extra')
                             .addClass('primer-spec-content-margin-auto');
                     }
                     else {
-                        $('.primer-spec-sidebar').css('display', 'inherit');
+                        $NODES.sidebar.css('display', 'inherit');
                         if (!isSmallScreen()) {
                             // On small screens, changing the margin causes the
-                            // content wrapping to change. 
+                            // content wrapping to change.
                             // Fow example, when a user clicks a link to a
                             // section in the sidebar on mobile and then
                             // collapses the sidebar, the content would shift
@@ -94,7 +146,7 @@
                             // page.
                             // To avoid this, we do not change the margin of the
                             // content on small screens.
-                            $('.markdown-body')
+                            $NODES.main_content
                                 .removeClass('primer-spec-content-margin-auto')
                                 .addClass('primer-spec-content-margin-extra');
                         }
@@ -102,14 +154,17 @@
                     sidebar_is_shown = !sidebar_is_shown;
                     return false;
                 }
-                $('.primer-spec-sidebar-toggle').on('click', toggleSidebar);
-
+                $NODES.sidebar_toggle_buttons.on('click', toggleSidebar);
 
                 // If this is a mobile browser, don't display the TOC.
                 if (isSmallScreen()) {
                     toggleSidebar();
                 }
 
+
+                /**
+                 * SIDEBAR: Hide in print preview
+                 */
 
                 // When students print the spec, the sidebar shouldn't show up.
                 // Despite trying to do this with CSS, the JS solution ends up
@@ -144,12 +199,16 @@
                 window.onafterprint = afterPrint;
 
 
+                /**
+                 * SIDEBAR: Display section location
+                 */
+
                 // Spy on where the user has scrolled and display that in the
                 // sidebar. Based on: https://codepen.io/eksch/pen/xwdOeK
                 $(window).scroll(function() {
                     var scrollDistance = $(window).scrollTop();
                     var threshold = $(window).height() / 2;
-                    $('h1, h2, h3, h4, h5, h6')
+                    $NODES.headings
                         .filter(function(i) {
                             return !$(this).hasClass('primer-spec-toc-ignore');
                         })
@@ -165,7 +224,48 @@
                             }
                         });
                 }).scroll();
+
+
+                /**
+                 * SUBTHEMES
+                 */
+
+                function _available_subthemes() {
+                    return {
+                        'default': "{{ "/assets/css/theme_default.css?v=" | append: site.github.build_revision | relative_url }}",
+                        'bella': "{{ "/assets/css/theme_bella.css?v=" | append: site.github.build_revision | relative_url }}"
+                    };
+                }
+                var subthemes = _available_subthemes()
+
+                Object.keys(subthemes).forEach(function (subtheme_name) {
+                    $NODES.subtheme_selector_dropdown.append(
+                        $('<option/>')
+                          .prop('value', subtheme_name)
+                          .append(subtheme_name)
+                    )
+                });
+
+                $NODES.subtheme_selector_dropdown.on('change', function () {
+                    var chosen_subtheme = $NODES.subtheme_selector_dropdown.val();
+                    $NODES.subtheme_stylesheet.prop('href', subthemes[chosen_subtheme]);
+                });
+
+
+                /**
+                 * SUBTHEME SETTINGS
+                 */
+
+                var settingsShown = false;
+                function toggleSettings() {
+                    $NODES.subtheme_settings_pane.attr('hidden', settingsShown);
+                    settingsShown = !settingsShown;
+                    return false;
+                }
+                $NODES.subtheme_settings_toggle_buttons
+                  .on('click', toggleSettings);
             })();
         </script>
+        <!-- END CUSTOM SPEC CODE -->
     </body>
 </html>

--- a/_sass/jekyll-theme-primer.scss
+++ b/_sass/jekyll-theme-primer.scss
@@ -4,5 +4,4 @@
 @import "primer-utilities/index.scss";
 @import "primer-layout/index.scss";
 @import "primer-markdown/index.scss";
-@import "spec/index.scss";
 @import "rouge";

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -1,3 +1,13 @@
+$SIDEBAR_WIDTH: 18em;
+$SIDEBAR_CONTENT_MARGIN: 0.5em;
+$SIDEBAR_BG_COLOR: white;
+$SIDEBAR_RIGHT_BORDER_STYLE: 1px solid lightgrey;
+$SIDEBAR_ACTIVE_ITEM_COLOR: yellow;
+
+$ICON_FONT_SIZE: 2em;
+$ICON_HOVER_COLOR: rgb(211, 85, 2);
+$TOPBAR_HEIGHT: $ICON_FONT_SIZE * 2;
+
 // For students printing out the spec, don't print the sidebar arrow.
 @media print {    
     .no-print, .no-print * {
@@ -5,47 +15,73 @@
     }
 }
 
-$SIDEBAR_WIDTH: 18em;
-$SIDEBAR_CONTENT_MARGIN: 0.5em;
-
 .primer-spec-sidebar {
     width: $SIDEBAR_WIDTH;
     padding-left: 1em;
     height: 100%;
     overflow: scroll;
-    border-right: 1px solid lightgrey;
+    border-right: $SIDEBAR_RIGHT_BORDER_STYLE;
+
+    // To make the sidebar appear on top of the topbar on mobile:
+    z-index: 1;
 
     // Need to set a background color because the sidebar overlays on top of
     // the content. (By default, the element has a transparent background.
-    background-color: white;
+    background-color: $SIDEBAR_BG_COLOR;
+
+    &-toggle-fixed {
+        font-size: $ICON_FONT_SIZE;
+        &.sidebar-shown {
+            display: none;
+        }
+    }
+}
+
+.primer-spec-settings-toggle {
+    font-size: $ICON_FONT_SIZE;
+}
+
+.primer-spec-topbar {
+    height: $TOPBAR_HEIGHT;
+    &-mobile {
+        background-color: white;
+    }
+}
+
+.primer-spec-float {
+    &-left {
+        position: absolute;
+        left: 1em;
+    }
+    &-right {
+        position: absolute;
+        right: 1em;
+    }
 }
 
 .primer-spec-hoverable {
     &:hover {
-        color: rgb(211, 85, 2);
+        color: $ICON_HOVER_COLOR;
         text-decoration: none;
-    }
-
-    &-fixed-to-page {
-        position: fixed;
-        top: 0.5em;
-        right: 1em;
-        font-size: 2em;
     }
 }
 
-.primer-spec-content-margin {
-    &-extra {
+.primer-spec-content {
+    &-margin-extra {
         // When the sidebar is shown, this ensures that the body of the page
         // does not overlap with the sidebar.
         // This is not done on small screens, because the sidebar overlays
         // on top of the content.
         margin-left: $SIDEBAR_WIDTH + $SIDEBAR_CONTENT_MARGIN;
     }
-    &-auto {
+    &-margin-auto {
         // When the sidebar is not shown, this ensures that the body of the
         // page stays centered like the default theme.
         margin-left: auto;
+    }
+    &-mobile {
+        // On mobile, make space for the topbar.
+        padding-top: $ICON_FONT_SIZE;
     }
 }
 
@@ -81,7 +117,7 @@ $SIDEBAR_CONTENT_MARGIN: 0.5em;
         font-size: 0.7em;
     }
     &-active {
-        background-color: yellow;
+        background-color: $SIDEBAR_ACTIVE_ITEM_COLOR;
     }
 }
 

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -5,9 +5,12 @@
     }
 }
 
+$SIDEBAR_WIDTH: 18em;
+$SIDEBAR_CONTENT_MARGIN: 0.5em;
+
 .primer-spec-sidebar {
-    width: 15em;
-    margin-left: 1em;
+    width: $SIDEBAR_WIDTH;
+    padding-left: 1em;
     height: 100%;
     overflow: scroll;
     border-right: 1px solid lightgrey;
@@ -18,13 +21,16 @@
 }
 
 .primer-spec-sidebar-toggle {
-    font-size: 3em;
-    position: fixed;
-    left: 5em;
-    top: 0.5em;
+    &-fixed-to-page {
+        position: fixed;
+        top: 0.5em;
+        right: 1em;
+        font-size: 2em;
+    }
 
-    :hover {
+    &:hover {
         color: rgb(211, 85, 2);
+        text-decoration: none;
     }
 }
 
@@ -34,7 +40,7 @@
         // does not overlap with the sidebar.
         // This is not done on small screens, because the sidebar overlays
         // on top of the content.
-        margin-left: 15.5em;
+        margin-left: $SIDEBAR_WIDTH + $SIDEBAR_CONTENT_MARGIN;
     }
     &-auto {
         // When the sidebar is not shown, this ensures that the body of the
@@ -48,31 +54,31 @@
         margin-left: auto;
         margin-top: 0.7em;
         font-weight: bold;
-        font-size: 1em;
+        font-size: 1.2em;
     }
     &-h2 {
         margin-left: 12px;
         margin-top: 0.5em;
         font-weight: bold;
-        font-size: 1em;
+        font-size: 1.2em;
     }
     &-h3 {
         margin-left: 24px;
         margin-top: 0.3em;
-        font-size: 0.9em;
+        font-size: 1em;
     }
     &-h4 {
         margin-left: 36px;
         font-style: italic;
-        font-size: 0.8em;
+        font-size: 0.9em;
     }
     &-h5 {
         margin-left: 48px;
-        font-size: 0.7em;
+        font-size: 0.8em;
     }
     &-h6 {
         margin-left: 56px;
-        font-size: 0.6em;
+        font-size: 0.7em;
     }
     &-active {
         background-color: yellow;

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -20,19 +20,17 @@ $SIDEBAR_CONTENT_MARGIN: 0.5em;
     background-color: white;
 }
 
-.primer-spec-sidebar-toggle {
+.primer-spec-hoverable {
+    &:hover {
+        color: rgb(211, 85, 2);
+        text-decoration: none;
+    }
+
     &-fixed-to-page {
         position: fixed;
         top: 0.5em;
         right: 1em;
         font-size: 2em;
-    }
-}
-
-.primer-spec-hoverable {
-    &:hover {
-        color: rgb(211, 85, 2);
-        text-decoration: none;
     }
 }
 
@@ -93,11 +91,4 @@ $SIDEBAR_CONTENT_MARGIN: 0.5em;
     width: 100%;
     min-height: 100%;
     height: 100%;
-
-    &-close-fixed {
-        font-size: 2em;
-        position: fixed;
-        top: 0.8em;
-        right: 1em;
-    }
 }

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -8,7 +8,7 @@ $ICON_FONT_SIZE: 2em;
 $ICON_HOVER_COLOR: rgb(211, 85, 2);
 $TOPBAR_HEIGHT: $ICON_FONT_SIZE * 2;
 
-// For students printing out the spec, don't print the sidebar arrow.
+// For students printing out the spec, don't print the sidebar and icons.
 @media print {    
     .no-print, .no-print * {
         display: none !important;
@@ -22,11 +22,11 @@ $TOPBAR_HEIGHT: $ICON_FONT_SIZE * 2;
     overflow: scroll;
     border-right: $SIDEBAR_RIGHT_BORDER_STYLE;
 
-    // To make the sidebar appear on top of the topbar on mobile:
+    // To make the sidebar appear on top of the topbar on mobile
     z-index: 1;
 
     // Need to set a background color because the sidebar overlays on top of
-    // the content. (By default, the element has a transparent background.
+    // the content. (By default, the element has a transparent background.)
     background-color: $SIDEBAR_BG_COLOR;
 
     &-toggle-fixed {
@@ -44,6 +44,8 @@ $TOPBAR_HEIGHT: $ICON_FONT_SIZE * 2;
 .primer-spec-topbar {
     height: $TOPBAR_HEIGHT;
     &-mobile {
+        // On mobile, the background prevents the icons from interfering
+        // with the text. Use with .primer-spec-content-mobile.
         background-color: white;
     }
 }

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -27,7 +27,9 @@ $SIDEBAR_CONTENT_MARGIN: 0.5em;
         right: 1em;
         font-size: 2em;
     }
+}
 
+.primer-spec-hoverable {
     &:hover {
         color: rgb(211, 85, 2);
         text-decoration: none;
@@ -82,5 +84,20 @@ $SIDEBAR_CONTENT_MARGIN: 0.5em;
     }
     &-active {
         background-color: yellow;
+    }
+}
+
+.primer-spec-settings {
+    background-color: white;
+    min-width: 100%;
+    width: 100%;
+    min-height: 100%;
+    height: 100%;
+
+    &-close-fixed {
+        font-size: 2em;
+        position: fixed;
+        top: 0.8em;
+        right: 1em;
     }
 }

--- a/_sass/spec/bella.theme.scss
+++ b/_sass/spec/bella.theme.scss
@@ -3,11 +3,12 @@
 @import "base.scss";
 
 $PRIMARY_COLOR: rgb(69, 98, 115);
+$SECONDARY_COLOR: rgb(246, 246, 246);
 $LINK_COLOR: rgb(219, 71, 93);
 $HEADING_COLOR: rgb(58, 58, 58);
 
 .primer-spec-sidebar {
-    background-color: rgb(246, 246, 246);
+    background-color: $SECONDARY_COLOR;
 }
 
 // Attribute selector for all primer-spec-toc-* classes

--- a/_sass/spec/bella.theme.scss
+++ b/_sass/spec/bella.theme.scss
@@ -1,0 +1,54 @@
+// Experimental theme designed by Bella Kim (kiminsun@umich.edu).
+
+@import "base.scss";
+
+$PRIMARY_COLOR: rgb(69, 98, 115);
+$LINK_COLOR: rgb(219, 71, 93);
+$HEADING_COLOR: rgb(58, 58, 58);
+
+.primer-spec-sidebar {
+    background-color: rgb(246, 246, 246);
+}
+
+// Attribute selector for all primer-spec-toc-* classes
+div[class^="primer-spec-toc-"] {
+    padding-left: 0.5em;
+    margin-left: auto;
+    :link, :visited {
+        color: $HEADING_COLOR;
+    }
+}
+
+.primer-spec-toc {
+    &-h1 {
+        :link, :visited {
+            color: $PRIMARY_COLOR !important;
+        }
+    }
+    &-h2 {
+        :link, :visited {
+            color: $PRIMARY_COLOR !important;
+        }
+    }
+    &-active {
+        background-color: $PRIMARY_COLOR !important;
+        border-radius: 5px 0px 0px 5px;
+        :link, :visited {
+            color: white !important;
+        }
+    }
+    &-section {
+        border-left: 0.15em solid $PRIMARY_COLOR;
+    }
+}
+
+h1, h2, h3, h4, h5, h6 {
+    color: $PRIMARY_COLOR;
+    :link, :visited {
+        color: $HEADING_COLOR;
+    }
+}
+
+:link, :visited {
+    color: $LINK_COLOR;
+}

--- a/_sass/spec/bella.theme.scss
+++ b/_sass/spec/bella.theme.scss
@@ -13,7 +13,7 @@ $HEADING_COLOR: rgb(58, 58, 58);
 // Attribute selector for all primer-spec-toc-* classes
 div[class^="primer-spec-toc-"] {
     padding-left: 0.5em;
-    margin-left: auto;
+    margin-left: 0em;
     :link, :visited {
         color: $HEADING_COLOR;
     }
@@ -23,6 +23,12 @@ div[class^="primer-spec-toc-"] {
     &-h1 {
         :link, :visited {
             color: $PRIMARY_COLOR !important;
+        }
+
+        // Only show the section border for H1 sections
+        &+.primer-spec-toc-section {
+            margin-left: 1em;
+            border-left: 0.15em solid $PRIMARY_COLOR;
         }
     }
     &-h2 {
@@ -36,9 +42,6 @@ div[class^="primer-spec-toc-"] {
         :link, :visited {
             color: white !important;
         }
-    }
-    &-section {
-        border-left: 0.15em solid $PRIMARY_COLOR;
     }
 }
 

--- a/_sass/spec/default.theme.scss
+++ b/_sass/spec/default.theme.scss
@@ -6,12 +6,6 @@
     background-color: white;
 }
 
-.primer-spec-sidebar-toggle {
-    &:hover {
-        color: rgb(211, 85, 2);
-    }
-}
-
 .primer-spec-toc {
     &-active {
         background-color: yellow;

--- a/_sass/spec/default.theme.scss
+++ b/_sass/spec/default.theme.scss
@@ -1,0 +1,19 @@
+// This is the default theme (based on the default Primer theme from GitHub).
+
+@import "base.scss";
+
+.primer-spec-sidebar {
+    background-color: white;
+}
+
+.primer-spec-sidebar-toggle {
+    &:hover {
+        color: rgb(211, 85, 2);
+    }
+}
+
+.primer-spec-toc {
+    &-active {
+        background-color: yellow;
+    }
+}

--- a/_sass/spec/metro.theme.scss
+++ b/_sass/spec/metro.theme.scss
@@ -2,12 +2,15 @@
 
 @import "base.scss";
 
-$PRIMARY_COLOR: rgb(69, 98, 115);
-$SECONDARY_COLOR: rgb(246, 246, 246);
-$LINK_COLOR: rgb(219, 71, 93);
-$HEADING_COLOR: rgb(58, 58, 58);
-$ACTIVE_COLOR: $PRIMARY_COLOR;
-$ACTIVE_TEXT_COLOR: white;
+$PRIMARY_COLOR: rgb(41, 82, 91);
+$SECONDARY_COLOR: rgb(41, 82, 91);
+$LINK_COLOR: rgb(233, 114, 110);
+$HEADING_COLOR: white;
+$ACTIVE_COLOR: rgb(248, 255, 248);
+$ACTIVE_TEXT_COLOR: $PRIMARY_COLOR;
+
+$ICON_COLOR: rgb(114, 202, 195);
+$TOC_H1_COLOR: rgb(229, 214, 204);
 
 .primer-spec-sidebar {
     background-color: $SECONDARY_COLOR;
@@ -25,18 +28,13 @@ div[class^="primer-spec-toc-"] {
 .primer-spec-toc {
     &-h1 {
         :link, :visited {
-            color: $PRIMARY_COLOR !important;
+            color: $TOC_H1_COLOR !important;
         }
 
         // Only show the section border for H1 sections
         &+.primer-spec-toc-section {
             margin-left: 1em;
-            border-left: 0.15em solid $PRIMARY_COLOR;
-        }
-    }
-    &-h2 {
-        :link, :visited {
-            color: $PRIMARY_COLOR !important;
+            border-left: 0.15em solid $TOC_H1_COLOR;
         }
     }
     &-active {
@@ -51,10 +49,17 @@ div[class^="primer-spec-toc-"] {
 h1, h2, h3, h4, h5, h6 {
     color: $PRIMARY_COLOR;
     :link, :visited {
-        color: $HEADING_COLOR;
+        color: $PRIMARY_COLOR;
     }
 }
 
 :link, :visited {
     color: $LINK_COLOR;
+}
+
+h2#contents {
+    color: $ICON_COLOR;
+    :link, :visited {
+        color: $ICON_COLOR;
+    }
 }

--- a/_sass/spec/xcode-dark.theme.scss
+++ b/_sass/spec/xcode-dark.theme.scss
@@ -1,0 +1,77 @@
+// Experimental theme designed by Bella Kim (kiminsun@umich.edu).
+
+@import "base.scss";
+
+$PRIMARY_COLOR: rgb(137, 135, 205);
+$SECONDARY_COLOR: rgb(242, 243, 243);
+$LINK_COLOR: rgb(222, 81, 78);
+$HEADING_COLOR: rgb(58, 58, 58);
+$ACTIVE_COLOR: rgb(90, 151, 247);
+$ACTIVE_TEXT_COLOR: white;
+
+$BG_COLOR: rgb(40, 41, 35);
+$TOC_SIDE_BORDER_COLOR: rgb(125, 125, 125);
+
+.primer-spec-sidebar {
+    background-color: $SECONDARY_COLOR;
+}
+
+// Attribute selector for all primer-spec-toc-* classes
+div[class^="primer-spec-toc-"] {
+    padding-left: 0.5em;
+    margin-left: 0em;
+    :link, :visited {
+        color: $HEADING_COLOR;
+    }
+}
+
+.primer-spec-toc {
+    &-h1 {
+        // Only show the section border for H1 sections
+        &+.primer-spec-toc-section {
+            margin-left: 1em;
+            border-left: 0.15em solid $TOC_SIDE_BORDER_COLOR;
+        }
+    }
+    &-active {
+        background-color: $ACTIVE_COLOR !important;
+        border-radius: 5px 0px 0px 5px;
+        :link, :visited {
+            color: $ACTIVE_TEXT_COLOR !important;
+        }
+    }
+}
+
+h1, h2, h3, h4, h5, h6 {
+    color: $PRIMARY_COLOR;
+    :link, :visited {
+        color: $PRIMARY_COLOR;
+    }
+}
+
+:link, :visited {
+    color: $LINK_COLOR;
+}
+
+// Make the text of code-blocks default to black (since the background-color
+// is the default primer color).
+.markdown-body {
+    .highlight pre.highlight {
+        color: black;
+    }
+
+    table {
+        color: black;
+    }
+}
+
+// Add the fancy dark background for the entire page.
+body, .markdown-body, .primer-spec-topbar-mobile {
+    background-color: $BG_COLOR;
+    color: white;
+}
+
+// Blockquotes looked too dark, make them lighter.
+.markdown-body blockquote {
+    color: mix(black, $SECONDARY_COLOR, 20%);
+}

--- a/assets/css/theme_bella.scss
+++ b/assets/css/theme_bella.scss
@@ -1,0 +1,5 @@
+---
+---
+
+@import "jekyll-theme-primer";
+@import "spec/bella.theme.scss";

--- a/assets/css/theme_default.scss
+++ b/assets/css/theme_default.scss
@@ -2,3 +2,4 @@
 ---
 
 @import "jekyll-theme-primer";
+@import "spec/default.theme.scss";

--- a/assets/css/theme_metro.scss
+++ b/assets/css/theme_metro.scss
@@ -1,0 +1,5 @@
+---
+---
+
+@import "jekyll-theme-primer";
+@import "spec/metro.theme.scss";

--- a/assets/css/theme_xcode-dark.scss
+++ b/assets/css/theme_xcode-dark.scss
@@ -1,0 +1,5 @@
+---
+---
+
+@import "jekyll-theme-primer";
+@import "spec/xcode-dark.theme.scss";

--- a/assets/js/html-table-of-contents.js
+++ b/assets/js/html-table-of-contents.js
@@ -30,6 +30,81 @@ function _getAnchorLink(headingNode) {
 }
 
 
+function _createHeadingToc(documentRef, heading, index, outputTocDiv) {
+    // If a heading already has an anchor from AnchorJS, use that
+    var href = '';
+    if (_nodeContainsAnchorChild(heading)) {
+        href = _getAnchorLink(heading);
+    }
+    else {
+        // Otherwise, create an anchor
+        href = '#toc' + index;
+        var anchor = documentRef.createElement('a');
+        anchor.setAttribute('name', 'toc' + index);
+        anchor.setAttribute('id', 'toc' + index);
+        heading.parentNode.insertBefore(anchor, heading);
+    }
+    
+    
+    var link = documentRef.createElement('a');
+    link.setAttribute('href', href);
+    link.textContent = heading.textContent;
+    
+    var div = documentRef.createElement('div');
+    div.setAttribute('class', 'primer-spec-toc-item primer-spec-toc-' + heading.tagName.toLowerCase());
+    
+    div.appendChild(link);
+    outputTocDiv.appendChild(div);
+}
+
+
+/**
+ * Generate a ToC heading and a single "section" given a list of `headings` DOM
+ *   elements starting from index `index`. The new ToC elements are placed
+ *   in `outputTocDiv`.
+ * 
+ * A "section" is defined to contain all subsequent headings with a tag-number
+ * larger than that of `headings[index]`. For instance, if
+ * `headings` contains a list of `[h1, h2, h2, h1, h3]`, the `h2` headings
+ * are included in the first `h1` section, and the `h3` heading is included in
+ * the second `h1` section. Note that all headings have their own sections,
+ * however their sections may be empty. (In this example, the non-`h1` headings
+ * all have empty sections.)
+ * As a result, this function operates in a recursive manner.
+ * @param {HTMLDOMDocument} documentRef - The `document` object.
+ * @param {Array<HTMLElement>} headings - A flat-list of heading DOM nodes.
+ * @param {number} index - The starting index into `headings`.
+ * @param {HTMLElement} outputTocDiv - The element where the heading 
+ *      and section indicated by `index` should be placed.
+ */
+function _generateToCSections(documentRef, headings, index, outputTocDiv) {
+    if (index >= headings.length) {
+        return index;
+    }
+
+    var heading = headings[index];
+    if (heading.classList.contains('primer-spec-toc-ignore')) {
+        return _generateToCSections(documentRef, headings, index + 1, outputTocDiv);
+    }
+
+    _createHeadingToc(documentRef, heading, index, outputTocDiv);
+    var sectionDiv = documentRef.createElement('div');
+    sectionDiv.setAttribute('class', 'primer-spec-toc-section');
+
+    var i = index + 1;
+    while (i < headings.length) {
+        if (headings[i].tagName[1] <= heading.tagName[1]) {
+            break;
+        }
+        else {
+            i = _generateToCSections(documentRef, headings, i, sectionDiv);
+        }
+    }
+    outputTocDiv.appendChild(sectionDiv);
+    return i;
+}
+
+
 /**
  * Generates a table of contents for your document based on the headings
  *  present. Anchors are injected into the document and the
@@ -37,8 +112,8 @@ function _getAnchorLink(headingNode) {
  *  contents will be generated inside of the first element with the id `toc`.
  * @param {HTMLDOMDocument} documentRef Optional A reference to the document
  *  object. Defaults to `document`.
+ * @author Sesh Sadasivam
  * @author Matthew Christopher Kastor-Inare III
- * @version 20130726
  * @url https://github.com/matthewkastor/html-table-of-contents
  * @example
  * // call this after the page has loaded
@@ -48,35 +123,9 @@ function htmlTableOfContents(documentRef) {
     var documentRef = documentRef || document;
     var toc = documentRef.getElementById('primer-spec-toc');
     var headings = [].slice.call(documentRef.body.querySelectorAll('h1, h2, h3, h4, h5, h6'));
-    headings.forEach(function (heading, index) {
-        // Ignore headings that should not be part of the ToC
-        if (heading.classList.contains('primer-spec-toc-ignore')) {
-            return;
-        }
 
-        // If a heading already has an anchor from AnchorJS, use that
-        var href = '';
-        if (_nodeContainsAnchorChild(heading)) {
-            href = _getAnchorLink(heading);
-        }
-        else {
-            // Otherwise, create an anchor
-            href = '#toc' + index;
-            var anchor = documentRef.createElement('a');
-            anchor.setAttribute('name', 'toc' + index);
-            anchor.setAttribute('id', 'toc' + index);
-            heading.parentNode.insertBefore(anchor, heading);
-        }
-        
-        
-        var link = documentRef.createElement('a');
-        link.setAttribute('href', href);
-        link.textContent = heading.textContent;
-        
-        var div = documentRef.createElement('div');
-        div.setAttribute('class', 'primer-spec-toc-item primer-spec-toc-' + heading.tagName.toLowerCase());
-        
-        div.appendChild(link);
-        toc.appendChild(div);
-    });
+    var index = 0;
+    while (index < headings.length) {
+        index = _generateToCSections(documentRef, headings, index, toc);
+    }
 }


### PR DESCRIPTION
Given that we've already created a wrapper for displaying the spec, I think theme support is the next logical step! This PR has a lot of changes — for the subthemes to be written efficiently, I needed to change how the code was organized. The code is now better organized and documented than before, so hopefully maintenance will be a bit easier.

_Tl;dr: See the live demo at http://www-personal.umich.edu/~seshrs/primer-spec-develop/. Then see the **"Maintenance notes and questions"** section at the end of this note._

## Summary
- Modified visual appearance of sidebar:
  - Sidebar is wider with larger text.
  - Sidebar toggle button now uses the recognizable "hamburger" icon.
  - Highlighted section in the sidebar is the section at the top of the viewer's screen. (Previously, it was whatever section that was above the middle of the screen.)
  - JavaScript code to generate the sidebar's table of contents now groups headings into "sections". (The new subthemes rely on this grouping to better style the sidebar.)
- Better mobile experience:
  - A "topbar" holds the sidebar-toggling button.
  - Clicking a link in the sidebar closes the sidebar.
- **SUBTHEME SUPPORT!**
  - Modified structure of stylesheets in `_sass/spec` to make it relatively easier to create new subthemes.
  - Added 3 new subtheme stylesheets: *bella*, *modern* and *xcode-dark*.
  - Added a "settings pane" in `_layouts/spec.html`. A dropdown menu allows viewers to choose a subtheme to use. (The settings pane, like the sidebar, does not show up when the webpage is printed.)
- Organized HTML and JavaScript code in `_layouts/spec.html` a little better:
  - Added comments, divided the script code into sections.
  - Made use of built-in GitHub Primer style classes.
  - Added a JQuery optimization to run the "selectors" (to find matching HTML elements) only once on page-load. This improves page performance.
- Made it easier to merge changes from up-stream by moving all Primer Spec modifications to new files.
- Updated README with instructions on adding subthemes.

### Live Demo
A live demo of the features described in this PR is available at http://www-personal.umich.edu/~seshrs/primer-spec-develop/.

## Validation
Please verify the visual appearance of the subthemes (including *default*) on your desktop/laptop/mobile device. Please play around with the sidebar toggles and the settings pane to ensure that they work as expected on your devices.

## Maintenance notes and questions
_CC: @awdeorio, @amirkamil_, @jamesjuett

Hopefully, the code is now a little better structured and documented with comments. As noted in the README, this repository needs to be [kept up-to-date with the upstream](https://github.com/eecs485staff/primer-spec#keeping-this-theme-up-to-date-with-primer) — this should be relatively easier after this PR is merged because all changes from upstream are contained in new external files.

In the unlikely event that problems occur and the spec does not render, simply update the project spec markdown file to use `layout: default` instead of `layout: spec` to use GitHub's default theme (without the sidebar.)

I wanted to discuss two options for deploying this PR (especially since changes to this repo affect EECS 485, EECS 280 and, potentially, EECS 490):

- Merge this PR with `master`. This is easier to maintain because we only maintain one branch. However, project specs from all these courses will begin using these new features when their websites are re-deployed. (Maybe this is not an issue given that project specs can revert to the default GitHub theme by using `layout: default`?)
- Maintain this subtheme feature in a separate branch, and require project specs to opt-in to showing subthemes. The opt-in would have to be done in the `_config.yml` file in each project repo. I personally think this is harder to maintain since we would have to support both the old style and the new style.

What do you think?


---

_Bella Kim (@bellakiminsun) suggested the idea of spec themes, designed the themes and provided usability feedback._