### PR TITLE
[Maintenance] Merge from upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
-sudo: false
-rvm: 2.5
+rvm: 2.6
 
 install: script/bootstrap
 script: script/cibuild

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'jekyll-remote-theme'

--- a/README.md
+++ b/README.md
@@ -215,8 +215,25 @@ To create a new subtheme:
 
 ## Keeping this theme up-to-date with Primer
 
-It's important to periodically check for changes from the [original upstream theme (Primer)](https://github.com/pages-themes/primer).
+It's important to periodically check for changes from the [original upstream theme (Primer)](https://github.com/pages-themes/primer). Follow these steps:
 
-- Compare the two repositories to check for changes. This can be achieved by [drafting a Pull Request](https://github.com/eecs485staff/primer-spec/compare/master...pages-themes:master).
+1. If you have not already done so, add the original upstream repo as a "remote" to your local Git setup. (This will allow you to cherry-pick commits.)
 
-- If there are changes, check the scope of changes. (If there are changes to `_layouts/default.html`, they will have to be reflected in `_layouts/spec.html` also.)
+```console
+$ pwd
+/users/seshrs/primer-spec
+$ git remote add upstream https://github.com/pages-themes/primer.git
+```
+
+2. Compare the two repositories to check for changes. This can be achieved by [drafting a Pull Request](https://github.com/eecs485staff/primer-spec/compare/master...pages-themes:master).
+
+3. If there are changes, check the scope of changes. (If there are changes to `_layouts/default.html`, they will have to be reflected in `_layouts/spec.html` also.)
+
+4. Create a new branch and cherry-pick the upstream commits. You may have to resolve merge conflicts.
+
+```console
+$ git checkout -b maintenance/f19
+$ git cherry-pick 72b7930 119b6e3
+```
+
+5. Push this branch to `origin` and [open a new Pull Request](https://github.com/eecs485staff/primer-spec/compare/master...eecs485staff:master).

--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ $ git remote add upstream https://github.com/pages-themes/primer.git
 
 3. If there are changes, check the scope of changes. (If there are changes to `_layouts/default.html`, they will have to be reflected in `_layouts/spec.html` also.)
 
-4. Create a new branch and cherry-pick the upstream commits. You may have to resolve merge conflicts.
+4. Create a new branch and merge the upstream master branch. You may have to resolve merge conflicts.
 
 ```console
 $ git checkout -b maintenance/f19
-$ git cherry-pick 72b7930 119b6e3
+$ git merge upstream/master maintenance/f19
 ```
 
 5. Push this branch to `origin` and [open a new Pull Request](https://github.com/eecs485staff/primer-spec/compare/master...eecs485staff:master).

--- a/jekyll-theme-primer-spec.gemspec
+++ b/jekyll-theme-primer-spec.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
   s.license       = 'MIT'
 
-  s.add_dependency 'jekyll', '~> 3.5'
+  s.add_dependency 'jekyll', '> 3.5', '< 5.0'
   s.add_runtime_dependency 'jekyll-github-metadata', '~> 2.9'
   s.add_runtime_dependency 'jekyll-seo-tag', '~> 2.0'
   s.add_development_dependency 'html-proofer', '~> 3.0'

--- a/jekyll-theme-primer-spec.gemspec
+++ b/jekyll-theme-primer-spec.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name          = 'jekyll-theme-primer-spec'
   s.version       = '0.1.0'

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,7 +3,7 @@
 set -e
 
 bundle exec jekyll build
-bundle exec htmlproofer ./_site --check-html --check-sri --disable-external
+bundle exec htmlproofer ./_site --check-html --check-sri
 bundle exec rubocop -D
 bundle exec script/validate-html
 gem build jekyll-theme-primer-spec.gemspec

--- a/script/validate-html
+++ b/script/validate-html
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'w3c_validators'
 


### PR DESCRIPTION
("Copy" of #5.)

A maintenance PR, as described in https://github.com/eecs485staff/primer-spec#keeping-this-theme-up-to-date-with-primer. Also fixes the build failure.

Also updated the maintenance instructions in the README to detail the steps I took to resolve merge conflicts. (I created a new branch and cherry-picked/merged commits from upstream.) I'm not certain if there's a more elegant approach, I'm open to other suggestions.