### PR TITLE
[Hotfix] Require specific Faraday version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'jekyll-remote-theme'
+
+# Neccessary to prevent Jekyll errors. See https://github.com/github/personal-website/issues/166
+gem 'faraday', '0.17.3'
+
 gemspec


### PR DESCRIPTION
Jekyll 3.8.6 seems to fail with the newest major release of Faraday (1.0.0). As suggested in github/personal-website#166, this PR ensures that the older version of Faraday is used in conjunction with Jekyll. (This should fix the Travis failures.)