### PR TITLE
Fix z-index layering of components

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -8,6 +8,16 @@ $ICON_FONT_SIZE: 2em;
 $ICON_HOVER_COLOR: rgb(211, 85, 2);
 $TOPBAR_HEIGHT: $ICON_FONT_SIZE * 2;
 
+// To ensure correct visual layering of the components on the page, we need
+// to specify these z-indices.
+// The sidebar is *always* on top of the topbar, which is always on top of
+// the settings modal.
+// When the settings modal is shown, it should always on top of any main
+// content (including MathJax content, which has z-index 0).
+$Z_INDEX_SETTINGS: 1;
+$Z_INDEX_TOPBAR: 2;
+$Z_INDEX_SIDEBAR: 3;
+
 // For students printing out the spec, don't print the sidebar and icons.
 @media print {
   .no-print,
@@ -26,7 +36,7 @@ $TOPBAR_HEIGHT: $ICON_FONT_SIZE * 2;
   border-right: $SIDEBAR_RIGHT_BORDER_STYLE;
 
   // To make the sidebar appear on top of the topbar on mobile
-  z-index: 1;
+  z-index: $Z_INDEX_SIDEBAR;
 
   &-toggle-fixed {
     font-size: $ICON_FONT_SIZE;
@@ -61,7 +71,7 @@ $TOPBAR_HEIGHT: $ICON_FONT_SIZE * 2;
   pointer-events: none;
 
   &-settings-shown {
-    z-index: 1;
+    z-index: $Z_INDEX_TOPBAR;
   }
 }
 
@@ -230,6 +240,7 @@ div[class^='primer-spec-toc-'] {
   &-container {
     display: none;
     background-color: var(--main-bg-color);
+    z-index: $Z_INDEX_SETTINGS;
   }
 
   &-toggle {


### PR DESCRIPTION
### Context

On Firefox and Safari, any LaTeX on the page rendered above the settings modal. (This also happened to the checkboxes at the end of EECS 280 specs.) Additionally, on mobile, it is difficult to close an open sidebar when the settings modal is open.

This commit updates the z-indices of Primer Spec components to reliably ensure correct visual ordering. The Sidebar must *always* appear above the Topbar, which must always appear above the Settings modal. When shown, the Settings modal should appear on top of any main content (including LaTeX and checkboxes).

### Validation

1) Visit PREVIEW#54 on Firefox or Safari desktop, scroll to the "LaTeX Support" section near the bottom of the page. Open the Settings modal. The LaTeX should not be visible.

2) Visit the Primer Spec site preview on a mobile browser. Open the sidebar, then open the Settings modal. The Topbar should not appear above the sidebar.

<table>
<tr>
  <th></th>
  <th>Before</th>
  <th>After</th>
</tr>
<tr>
  <td>LaTeX on desktop</td>
  <td><img width="1440" alt="Screen Shot 2020-06-21 at 1 59 07 PM" src="https://user-images.githubusercontent.com/12139762/85231904-13310700-b3c9-11ea-9636-e9a53698d1e0.png"></td>
  <td><img width="1291" alt="Screen Shot 2020-06-21 at 1 58 19 PM" src="https://user-images.githubusercontent.com/12139762/85231911-204df600-b3c9-11ea-9fda-9b60681e56c9.png"></td>
</tr>
<tr>
  <td>Sidebar + Settings on mobile</td>
  <td><img src="https://user-images.githubusercontent.com/12139762/85231991-ddd8e900-b3c9-11ea-92ef-ac7da534790e.jpeg"></td>
  <td><img src="https://user-images.githubusercontent.com/12139762/85231986-c699fb80-b3c9-11ea-8b48-77cc6ac88a8c.jpeg"></td>
</tr>
</table>