### PR TITLE
Fix LaTeX rendering

### DIFF
--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -29,6 +29,7 @@ version_string: v1.3
              */
             mjx-container {
                 overflow: auto;
+                overflow-y: hidden;
             }
         </style>
         {%- endif %}

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -31,6 +31,15 @@ version_string: v1.3
                 overflow: auto;
                 overflow-y: hidden;
             }
+
+            /**
+             * On mobile (at least on iOS), the 0-line-height style from
+             * MathJax causes rendering issues with inline math. This style
+             * overrides the property. (Needed to add specificity to override.)
+             */
+             mjx-container[jax="CHTML"].MathJax {
+              line-height: inherit;
+            }
         </style>
         {%- endif %}
         <!-- END CUSTOM SPEC CODE -->

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -29,7 +29,6 @@ version_string: v1.3
              */
             mjx-container {
                 overflow: auto;
-                overflow-y: hidden;
             }
         </style>
         {%- endif %}

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -13,10 +13,10 @@ $TOPBAR_HEIGHT: $ICON_FONT_SIZE * 2;
 // The sidebar is *always* on top of the topbar, which is always on top of
 // the settings modal.
 // When the settings modal is shown, it should always on top of any main
-// content (including MathJax content, which has z-index 0).
-$Z_INDEX_SETTINGS: 1;
-$Z_INDEX_TOPBAR: 2;
-$Z_INDEX_SIDEBAR: 3;
+// content (including MathJax content, which has z-index 1).
+$Z_INDEX_SETTINGS: 2;
+$Z_INDEX_TOPBAR: 3;
+$Z_INDEX_SIDEBAR: 4;
 
 // For students printing out the spec, don't print the sidebar and icons.
 @media print {

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -69,10 +69,7 @@ $Z_INDEX_SIDEBAR: 3;
   // We don't want the Topbar to register click events. This allows clicks to
   // pass-through to underlying main-content.
   pointer-events: none;
-
-  &-settings-shown {
-    z-index: $Z_INDEX_TOPBAR;
-  }
+  z-index: $Z_INDEX_TOPBAR;
 }
 
 /**


### PR DESCRIPTION
This PR fixes two rendering issues related to LaTeX:

- LaTeX used to render on top of the Topbar on mobile if the Settings pane wasn't shown. This commit fixes the Topbar z-index to *always* be on top of main content.
- On Safari, LaTeX blocks would annoying scroll independently on the page (despite having no real overflow). This commit specifies that vertical overflow should always be hidden on LaTeX.