### PR TITLE
Use script defer instead of preload

### DIFF
--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -18,7 +18,7 @@ version_string: v1.3
             {% assign base_url = "https://eecs485staff.github.io/primer-spec" %}
         {% endif %}
         <link rel="stylesheet" href="{{ base_url }}/assets/{{ layout.version_string }}/css/primer-spec-base.css">
-        <link rel="preload" href="{{ base_url }}/assets/{{ layout.version_string }}/js/primer_spec_plugin.min.js" as="script" crossorigin>
+        <script src="{{ base_url }}/assets/{{ layout.version_string }}/js/primer_spec_plugin.min.js" crossorigin="anonymous" defer></script>
 
         {%- if page.latex %}
         <style>
@@ -76,7 +76,6 @@ version_string: v1.3
         {% endif %}
 
         <!-- BEGIN CUSTOM SPEC CODE -->
-        <script src="{{ base_url }}/assets/{{ layout.version_string }}/js/primer_spec_plugin.min.js" crossorigin="anonymous"></script>
         {%- if page.latex %}
         <script>
             // This config was derived from the config TeX-MML-AM_CHTML, but

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -172,21 +172,11 @@ However, with some work, it is _possible_ to add Primer Spec styling to a plain 
      rel="stylesheet"
      href="https://eecs485staff.github.io/primer-spec/assets/<version>/css/primer-spec-base.css"
    />
-   <link
-     rel="preload"
-     href="https://eecs485staff.github.io/primer-spec/assets/<version>/js/primer_spec_plugin.min.js"
-     as="script"
-     crossorigin
-   />
-   ```
-
-4. Add the following lines at the bottom of the file, just before the closing `body` tag. Again, replace `<version>` with the appropriate version in the [`assets/`](../assets/) directory.
-
-   ```html
    <script
-     src="https://eecs485staff.github.io/primer-spec/assets/<version>/js/primer_spec_plugin.min.js"
-     crossorigin="anonymous"
-   ></script>
+      src="https://eecs485staff.github.io/primer-spec/assets/<version>/js/primer_spec_plugin.min.js"
+      crossorigin="anonymous"
+      defer
+    ></script>
    ```
 
 Your final HTML file will probably look something like this:
@@ -200,12 +190,11 @@ Your final HTML file will probably look something like this:
       rel="stylesheet"
       href="https://eecs485staff.github.io/primer-spec/assets/<version>/css/primer-spec-base.css"
     />
-    <link
-      rel="preload"
-      href="https://eecs485staff.github.io/primer-spec/assets/<version>/js/primer_spec_plugin.min.js"
-      as="script"
-      crossorigin
-    />
+    <script
+      src="https://eecs485staff.github.io/primer-spec/assets/<version>/js/primer_spec_plugin.min.js"
+      crossorigin="anonymous"
+      defer
+    ></script>
 
     <title>My long project spec</title>
   </head>
@@ -220,10 +209,6 @@ Your final HTML file will probably look something like this:
       <h2>Grading</h2>
       ...
     </div>
-    <script
-      src="https://eecs485staff.github.io/primer-spec/assets/<version>/js/primer_spec_plugin.min.js"
-      crossorigin="anonymous"
-    ></script>
   </body>
 </html>
 ```


### PR DESCRIPTION
As far as I can tell, preloading scripts has the same effect as using the [`defer` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#:~:text=This%20Boolean%20attribute%20is%20set%20to%20indicate%20to%20a%20browser%20that%20the%20script%20is%20meant%20to%20be%20executed%20after%20the%20document%20has%20been%20parsed,%20but%20before%20firing%20DomContentLoaded.). Using `defer` makes the non-Jekyll setup easier, so we might as well switch to that.