### PR TITLE
Add support for favicons

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
 
 {% seo %}
       {%- if site.favicon %}
-      <link rel="icon" href="{{ site.favicon }}">
+      <link rel="icon" href="{{ site.favicon | relative_url }}">
       {%- endif %}
     <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
   </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
 {% seo %}
+      {%- if site.favicon %}
+      <link rel="icon" href="{{ site.favicon }}">
+      {%- endif %}
     <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
   </head>
   <body>

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -10,7 +10,7 @@ version_string: v1.4
 {% seo %}
 
         {%- if site.favicon %}
-        <link rel="icon" href="{{ site.favicon }}">
+        <link rel="icon" href="{{ site.favicon | relative_url }}">
         {%- endif %}
 
         {%- if jekyll.environment == "dev" %}

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -9,6 +9,10 @@ version_string: v1.4
         <meta name="viewport" content="width=device-width, initial-scale=1">
 {% seo %}
 
+        {%- if site.favicon %}
+        <link rel="icon" href="{{ site.favicon }}">
+        {%- endif %}
+
         {%- if jekyll.environment == "dev" %}
             {% assign base_url = "http://localhost:4000" %}
         {% elsif jekyll.environment == "site-preview" %}

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -14,12 +14,12 @@ See the [Primer Spec README](../README.md) for the main usage instructions. This
 - [Customizing Jekyll](#customizing-jekyll)
 - [Hiding sections from the sidebar](#hiding-sections-from-the-sidebar)
 - [Page configuration options](#page-configuration-options)
-  - [`disableSidebar`: Boolean](#disablesidebar-boolean)
-  - [`hideSidebarOnLoad`: Boolean](#hidesidebaronload-boolean)
-  - [`latex`: Boolean](#latex-boolean)
+    - [`disableSidebar`: Boolean](#disablesidebar-boolean)
+    - [`hideSidebarOnLoad`: Boolean](#hidesidebaronload-boolean)
+    - [`latex`: Boolean](#latex-boolean)
 - [Site configuration options](#site-configuration-options)
-  - [`defaultSubthemeName`: String](#defaultsubthemename-string)
-  - [`defaultSubthemeMode`: String](#defaultsubthememode-string)
+    - [`defaultSubthemeName`: String](#defaultsubthemename-string)
+    - [`defaultSubthemeMode`: String](#defaultsubthememode-string)
 - [Using without Jekyll](#using-without-jekyll)
 
 ## Previewing locally
@@ -106,6 +106,7 @@ description: [A short description of your site's purpose]
 Additionally, you may choose to set the following optional variables:
 
 ```yml
+favicon: [Path/URL to 32x32 favicon]
 google_analytics: [Your Google Analytics tracking ID]
 ```
 


### PR DESCRIPTION
## Context

EECS 485 has a custom favicon, and other courses' staff may be considering adding favicons to help students find the project-spec tabs in their browsers. This PR allows course staff to configure favicons to be used for all pages on their site.

I also think it would be great to see this feature make its way to the original Primer theme. I've opened pages-themes/primer#42 to request adding this support.

## Validation

Pull the branch locally.

1) Add the following line to `_config.yml`:
    ```yml
    favicon: https://eecs485staff.github.io/eecs485.org/favicon.ico
    ```

    Run `script/server` and visit http://localhost:4000 —- the site's favicon should display in the browser tab list.

    ![image](https://user-images.githubusercontent.com/12139762/92414225-588be780-f121-11ea-95ff-b8db90ef66de.png)

2) Remove the line from `_config.yml` and restart `script/server`. Refresh the page on your browser, and notice that the browser uses a default placeholder favicon in the tab list.

    ![image](https://user-images.githubusercontent.com/12139762/92414258-7eb18780-f121-11ea-9729-0adc281b3fed.png)
