### PR TITLE
[RFC] Prevent long headings from increasing Sidebar's width

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -118,6 +118,11 @@ $Z_INDEX_SIDEBAR: 4;
   &-item {
     // Prevent header items from ending too near the border of the Sidebar
     padding-right: 1em;
+    // If a heading item is too long and cannot be broken by the browser,
+    // don't expand the width of the entire Sidebar. Instead, only make the
+    // "offending" heading scrollable. (Kind-of-like how we currently treat
+    // code-blocks and LaTeX on small screens.)
+    overflow: scroll;
   }
 
   &-h1 {

--- a/demo/long-headings.md
+++ b/demo/long-headings.md
@@ -1,0 +1,35 @@
+---
+layout: spec
+---
+
+# Long Headings
+
+{: .primer-spec-toc-ignore }
+
+This page demonstrates Primer Spec's handling of long headings in the Sidebar. We achieve this by using the CSS property `overflow: scroll` on potentially long elements that should not affect the width of its container
+
+## Short heading
+
+## This is a mid-sized heading.
+
+## Here's a longer-than-average heading with thirteen words and eighty-four characters.
+
+## Some of my favorite long words: Supercalifragilisticexpialidocious, antidisestablishmentarianism, flocci­nauci­nihili­pili­fication, electroencephalographically
+
+I copied the words from [Wikipedia](https://en.wikipedia.org/wiki/Longest_word_in_English), and it looks like the editors added "soft hyphens" (U+00AD) to `flocci­nauci­nihili­pili­fication` — this is why the word breaks neatly in the Sidebar.
+
+## Tau­mata­whaka­tangi­hanga­koau­auota­matea­pokai­when­uaki­tana­tahu
+
+I copied this from [Wikipedia](https://en.wikipedia.org/wiki/Longest_word_in_English#Notable_long_words), and it looks like the editors added "soft hyphens" (U+00AD) to the string to allow it to break neatly in the Sidebar.
+
+## Bababadalgharaghtakamminarronnkonnbronntonnerronntuonnthunntrovarrhounawnskawntoohoohoordenenthurnuk
+
+## It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way—in short, the period was so far like the present period, that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only.
+
+## [Ignore me] Padding
+
+Here's some padding at the end of this page to test scrolling to the above headings.
+
+Here's a transcription of the sounds when Link tames a horse during Legend of Zelda: Breath of the Wild:
+
+Clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop clip clop.


### PR DESCRIPTION
## Context

I noticed that if a heading is extra-long and cannot be broken by default Unicode text-break rules, the *entire* Sidebar's width increases and becomes horizontally scrollable. Not only does this feel like a weird experience, but this also looks bad!

Here's an example from an EECS 441 spec: https://eecs441.eecs.umich.edu/asns/lab1-kotlinImages#a-known-issues-with-mediastoreactionvideocapture

![image](https://user-images.githubusercontent.com/12139762/93714862-697e2500-fb33-11ea-8f53-ded69d3c61e6.png)

This PR proposes to add an `overflow` property to all Sidebar heading items. This means that the width of a heading item *will not* affect the Sidebar's width; instead, the heading item **alone** will become scrollable. (This approach is similar to how code-blocks and LaTeX blocks are scrollable on small screens.)

![image](https://user-images.githubusercontent.com/12139762/93717296-e95fbb80-fb42-11ea-961e-bdf33761a94e.png)


I think this is acceptable given that most specs do not feature long headings. However, I'm interested in hearing opinions about this approach, and whether it provides for a confusing UX.

## Validation

Visit the validation URL at PREVIEW#84. The headings shouldn't look any different, even on mobile devices.

Then visit https://preview.seshrs.ml/previews/eecs485staff/primer-spec/84/demo/long-headings.html, whose sidebar is filled with long heading items.