### PR TITLE
Hide unnecessary scrollbars on Windows

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -32,7 +32,7 @@ $Z_INDEX_SIDEBAR: 4;
   width: $SIDEBAR_WIDTH;
   padding-left: 1em;
   height: 100%;
-  overflow: scroll;
+  overflow: auto;
   border-right: $SIDEBAR_RIGHT_BORDER_STYLE;
 
   // To make the sidebar appear on top of the topbar on mobile
@@ -122,7 +122,7 @@ $Z_INDEX_SIDEBAR: 4;
     // don't expand the width of the entire Sidebar. Instead, only make the
     // "offending" heading scrollable. (Kind-of-like how we currently treat
     // code-blocks and LaTeX on small screens.)
-    overflow: scroll;
+    overflow: auto;
   }
 
   &-h1 {

--- a/demo/long-headings.md
+++ b/demo/long-headings.md
@@ -6,7 +6,7 @@ layout: spec
 
 {: .primer-spec-toc-ignore }
 
-This page demonstrates Primer Spec's handling of long headings in the Sidebar. We achieve this by using the CSS property `overflow: scroll` on potentially long elements that should not affect the width of its container
+This page demonstrates Primer Spec's handling of long headings in the Sidebar. We achieve this by using the CSS property `overflow: auto` on potentially long elements that should not affect the width of its container
 
 ## Short heading
 


### PR DESCRIPTION
## Context

I used the `overflow: scroll` CSS property on certain wide/tall elements so that their width/height do not affect the width/height of their parent elements. For instance, this property was applied to each ToC item in the Sidebar so that any single wide ToC item would not cause the entire Sidebar to scroll horizontally.

Unfortunately, I should have been using `overflow: auto` instead so that scrollbars are hidden when not necessary. I don't know why I forgot about that, but @sbeinlich reminded me while refactoring the eecs485.org website. (Thanks @sbeinlich!)

This PR changes all occurrences of `overflow: scroll` to `overflow: auto`.

## Validation

Visit PREVIEW#86 on a Windows computer. I used Chrome 86 on Windows 10 via [browserstack.com](https://www.browserstack.com).

**Before** (note the ugly scrollbars in the Sidebar):
![image](https://user-images.githubusercontent.com/12139762/97790235-47011200-1b9d-11eb-924a-df8cf987af6d.png)


**After**:
![image](https://user-images.githubusercontent.com/12139762/97790209-128d5600-1b9d-11eb-91b7-518f42d72c75.png)


Also view the long-headings demo page.

**Before** (all Sidebar items have scrollbars):
![image](https://user-images.githubusercontent.com/12139762/97790267-98a99c80-1b9d-11eb-855a-ac87e7f788bf.png)

**After** (only the long Sidebar items have scrollbars):
![image](https://user-images.githubusercontent.com/12139762/97790276-a65f2200-1b9d-11eb-894f-45dd440c379c.png)

