### PR TITLE
Disallow PRs to any branch besides develop

### DIFF
--- a/.github/workflows/verify-pr-base-branch.yml
+++ b/.github/workflows/verify-pr-base-branch.yml
@@ -1,15 +1,15 @@
-name: verify-pr-target-branch
+name: verify-pr-base-branch
 
 on:
   pull_request:
 
 jobs:
-  verify-pr-target-branch:
-    name: verify-pr-target-branch
+  verify-pr-base-branch:
+    name: verify-pr-base-branch
     runs-on: ubuntu-latest
     steps:
-      - name: Get target branch
-        id: get-pr-target-branch
+      - name: Get base branch
+        id: get-pr-base-branch
         uses: actions/github-script@v3
         with:
           script: |
@@ -18,12 +18,11 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
-            console.log('@@@ debugging, got pr', pr);
-            return pr.head.label;
+            return pr.data.base.ref;
           result-encoding: string
 
-      - name: Update PR if wrong branch
-        if: ${{ steps.get-pr-target-branch.outputs.result != 'develop' }}
+      - name: Update PR if wrong base branch
+        if: ${{ steps.get-pr-base-branch.outputs.result != 'develop' }}
         uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/verify-pr-base-branch.yml
+++ b/.github/workflows/verify-pr-base-branch.yml
@@ -27,15 +27,15 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            await github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "Thanks for opening this pull request! 🙏<br><br>I've changed this PR's base branch to `develop`. A maintainer will review your PR soon!",
-            })
             await github.pulls.update({
               pull_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               base: 'develop',
-            })
+            });
+            await github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Thanks for opening this pull request! 🙏<br><br>I've changed this PR's base branch to `develop`. A maintainer will review your PR soon!",
+            });

--- a/.github/workflows/verify-pr-target-branch.yml
+++ b/.github/workflows/verify-pr-target-branch.yml
@@ -18,6 +18,7 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
+            console.log('@@@ debugging, got pr', pr);
             return pr.head.label;
           result-encoding: string
 

--- a/.github/workflows/verify-pr-target-branch.yml
+++ b/.github/workflows/verify-pr-target-branch.yml
@@ -1,0 +1,42 @@
+name: verify-pr-target-branch
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  verify-pr-target-branch:
+    name: verify-pr-target-branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get target branch
+        id: get-pr-target-branch
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const pr = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            return pr.head.label;
+          result-encoding: string
+
+      - name: Update PR if wrong branch
+        if: ${{ steps.get-pr-target-branch.outputs.result != 'develop' }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            await github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Thanks for opening this pull request! 🙏<br><br>I've changed this PR's base branch to `develop`. A maintainer will review your PR soon!",
+            })
+            await github.pulls.update({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'develop',
+            })

--- a/.github/workflows/verify-pr-target-branch.yml
+++ b/.github/workflows/verify-pr-target-branch.yml
@@ -2,7 +2,6 @@ name: verify-pr-target-branch
 
 on:
   pull_request:
-    types: [opened]
 
 jobs:
   verify-pr-target-branch:


### PR DESCRIPTION
## Context

As discussed in #109, we need to make `master` the default branch. But this means that if contributors propose pull requests to this repo, their PRs will target `master` by default!

This PR adds a GH Actions workflow to change the base branch of a PR if it was opened to any branch besides `develop`.

Closes #109. CC @awdeorio, @jadchaar 

## Validation

To test, I intentionally opened this PR on `master`. If all goes, well, GH Actions should change the base branch and comment on this PR.

EDIT: It did! 🚀 