### PR TITLE
Update Google Analytics snippet to use gtag.js

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,13 +28,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js" integrity="sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg=" crossorigin="anonymous"></script>
     <script>anchors.add();</script>
     {% if site.google_analytics %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', '{{ site.google_analytics }}', 'auto');
-      ga('send', 'pageview');
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '{{ site.google_analytics }}');
     </script>
     {% endif %}
   </body>

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -114,13 +114,14 @@ version_string: v1.5
         </div> <!-- .container-lg -->
 
         {% if site.google_analytics %}
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
         <script>
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-            ga('create', '{{ site.google_analytics }}', 'auto');
-            ga('send', 'pageview');
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', '{{ site.google_analytics }}');
         </script>
         {% endif %}
     </body>

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -112,7 +112,7 @@ Additionally, you may choose to set the following optional variables:
 
 ```yml
 favicon: [Path/URL to 32x32 favicon]
-google_analytics: [Your Google Analytics tracking ID]
+google_analytics: [Your Google Analytics tracking ID / measurement ID]
 ```
 
 ## Hiding sections from the sidebar


### PR DESCRIPTION
Google Analytics has deprecated the use of `analytics.js` and instead encourages users to use `gtag.js`. This change is backwards-compatible because `gtag.js` supports both the newer `G-xxxx` measurement ID and the older `UA-xxxx` tracking ID formats.

I will cherry-pick these commits to current `master` and release the change as v1.4.2. CC @eecs441staff

Closes #120.