### PR TITLE
Always include icons in Callouts

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -529,29 +529,27 @@ $CALLOUT_VARIANTS: (
   ),
 );
 
-.markdown-body {
-  .primer-spec-callout {
-    position: relative;
-    padding: 20px 16px;
-    border-style: solid;
-    border-width: 1px;
-    border-radius: 6px;
+.primer-spec-callout {
+  position: relative;
+  padding: 20px 16px;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 6px;
 
-    @each $variant, $props in $CALLOUT_VARIANTS {
-      &.#{$variant} {
-        background-color: var(
-          --primer-spec-callout-#{$variant}-bg-color,
-          map-get($props, 'bg')
-        );
-        border-color: var(
-          --primer-spec-callout-#{$variant}-border-color,
-          map-get($props, 'border')
-        );
-        color: var(
-          --primer-spec-callout-#{$variant}-text-color,
-          map-get($props, 'color')
-        );
-      }
+  @each $variant, $props in $CALLOUT_VARIANTS {
+    &.#{$variant} {
+      background-color: var(
+        --primer-spec-callout-#{$variant}-bg-color,
+        map-get($props, 'bg')
+      );
+      border-color: var(
+        --primer-spec-callout-#{$variant}-border-color,
+        map-get($props, 'border')
+      );
+      color: var(
+        --primer-spec-callout-#{$variant}-text-color,
+        map-get($props, 'color')
+      );
     }
   }
 

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -552,24 +552,24 @@ $CALLOUT_VARIANTS: (
       );
     }
   }
+}
 
-  // We want to style div callouts like p elements.
-  div.primer-spec-callout {
-    margin-top: 0px;
-    margin-bottom: 16px;
-    padding-bottom: 4px;
-  }
+// We want to style div callouts like p elements.
+div.primer-spec-callout {
+  margin-top: 0px;
+  margin-bottom: 16px;
+  padding-bottom: 4px;
+}
 
-  // Style the icons
-  @each $variant, $props in $CALLOUT_VARIANTS {
-    p.primer-spec-callout.#{$variant},
-    div.primer-spec-callout.#{$variant} > p:first-child {
-      &::before {
-        padding-right: 8px;
-        font-family: 'Font Awesome 5 Free';
-        font-weight: 900;
-        content: map-get($props, 'icon');
-      }
+// Style the icons
+@each $variant, $props in $CALLOUT_VARIANTS {
+  p.primer-spec-callout.#{$variant},
+  div.primer-spec-callout.#{$variant} > p:first-child {
+    &::before {
+      padding-right: 8px;
+      font-family: 'Font Awesome 5 Free';
+      font-weight: 900;
+      content: map-get($props, 'icon');
     }
   }
 }

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -564,8 +564,8 @@ $CALLOUT_VARIANTS: (
 
   // Style the icons
   @each $variant, $props in $CALLOUT_VARIANTS {
-    p.primer-spec-callout.icon-#{$variant},
-    div.primer-spec-callout.icon-#{$variant} > p:first-child {
+    p.primer-spec-callout.#{$variant},
+    div.primer-spec-callout.#{$variant} > p:first-child {
       &::before {
         padding-right: 8px;
         font-family: 'Font Awesome 5 Free';

--- a/demo/callouts.md
+++ b/demo/callouts.md
@@ -9,11 +9,11 @@ layout: spec
 
 Use Callouts when you want to elevate information and draw attention to it. Use these components sparingly!
 
-<p class="primer-spec-callout success icon-success" markdown="1">
+<p class="primer-spec-callout success" markdown="1">
 All of these callouts work great in dark mode too!
 </p>
 
-<div class="primer-spec-callout info icon-info" markdown="1">
+<div class="primer-spec-callout info" markdown="1">
 You can include code blocks in your callouts too!
 
 ```c++
@@ -103,76 +103,6 @@ _**Pro tip:** Use this to celebrate an achievement!_
   ```markdown
 <div class="primer-spec-callout success" markdown="1">
   _**Pro tip:** Use this to celebrate an achievement!_
-</div>
-  ```
-</details>
-
-## Usage with icons
-
-You can also include an icon with each callout. You can use any icon with any callout-variant, but we stronly recommend using the icons with the variant in their names.
-
-See below for recommended exmaples.
-
-### `info` icon
-
-<div class="primer-spec-callout info icon-info" markdown="1">
-A callout with an "info" icon.
-</div>
-
-<details markdown="1">
-  <summary><code>info</code> icon source</summary>
-  
-  ```markdown
-<div class="primer-spec-callout info icon-info" markdown="1">
-  A callout with an "info" icon.
-</div>
-  ```
-</details>
-
-### `warning` icon
-
-<div class="primer-spec-callout warning icon-warning" markdown="1">
-A callout with an excalamation-triangle icon.
-</div>
-
-<details markdown="1">
-  <summary><code>warning</code> icon source</summary>
-  
-  ```markdown
-<div class="primer-spec-callout warning icon-warning" markdown="1">
-  A callout with an excalamation-triangle icon.
-</div>
-  ```
-</details>
-
-### `danger` icon
-
-<div class="primer-spec-callout danger icon-danger" markdown="1">
-A callout with an excalamation-circle icon.
-</div>
-
-<details markdown="1">
-  <summary><code>danger</code> icon source</summary>
-  
-  ```markdown
-<div class="primer-spec-callout danger icon-danger" markdown="1">
-  A callout with an excalamation-circle icon.
-</div>
-  ```
-</details>
-
-### `success` icon
-
-<div class="primer-spec-callout success icon-success" markdown="1">
-A callout with a check-mark icon.
-</div>
-
-<details markdown="1">
-  <summary><code>success</code> icon source</summary>
-  
-  ```markdown
-<div class="primer-spec-callout success icon-success" markdown="1">
-  A callout with a check-mark icon.
 </div>
   ```
 </details>

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -152,7 +152,7 @@ In HTML files, this can be achieved by adding a `class` attribute to the heading
 Use Callouts to highlight information in your specs. Here's an example:
 
 ```markdown
-<div class="primer-spec-callout info icon-info" markdown="1">
+<div class="primer-spec-callout info" markdown="1">
   This is an example callout.
   If you use this in a `markdown` file, *markdown* works inside the box too!
 </p>


### PR DESCRIPTION
Yet another Callouts PR! 😅 

I gave some thought to the accessibility of callouts, and I realized that the default callout API "discouraged" the use of icons for the sake of flexibility — it was possible to use any icon-variant with any callout-variant.

However, I can't think of any good reason why one would want to use the triangular-warning-icon with a green-success callout. Further, excluding icons (or using the wrong icon) can be particularly confusing for students with visual impairments and who are unable to distinguish certain colors.

Hence, this PR removes the ability to customize the icon per-callout, and _always_ displays an icon for each callout. See the new preview page: https://preview.seshrs.ml/previews/eecs485staff/primer-spec/122/demo/callouts.html

---

PS: The callouts don't work super-well with screen-readers yet (they are treated just like any other paragraph). I'm still trying to figure out a good way of adding screen-reader-only text without changing the Callouts API.