### PR TITLE
Update docs and workflow references to master branch, sync main branch

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - master # NOTE: Remove this line when master branch is removed.
+      - main
       - develop
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,23 @@ jobs:
           git add VERSION assets
           STAGE_STATIC_ASSETS=true git commit -m "Freeze version v$(cat VERSION)"
 
+      - name: Checkout main
+        run: |
+          git checkout main
+
+      - name: 𖢞 Merge to main
+        run: |
+          git merge develop
+
+      - name: Push to main
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+
+      # NOTE: Temporarily keep master and main in sync, until master has been
+      # removed.
+
       - name: Checkout master
         run: |
           git checkout master
@@ -51,10 +68,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master
 
+      # NOTE: End of temporary sync section to be deleted in future.
+
       - name: Merge back to develop
         run: |
           git checkout develop
-          git merge master
+          git merge main
 
       - name: Push to develop
         uses: ad-m/github-push-action@master

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Primer Spec is a Jekyll theme, which means you can start using this theme with [
 3. If it doesn't already exist, create a file `_config.yml` in your site's root directory. Add this content to the file:
 
    ```yml
-   remote_theme: eecs485staff/primer-spec@master
+   remote_theme: eecs485staff/primer-spec
    plugins:
      - jekyll-remote-theme
      - jekyll-optional-front-matter

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -108,18 +108,18 @@ This theme is used by [several courses at the University of Michigan](../README.
 
 Some notes about maintaining this project:
 
-1. [Create a new release by syncing `develop` and `master`](#releasing-for-the-next-semester)
+1. [Create a new release by syncing `develop` and `main`](#releasing-for-the-next-semester)
 2. [Bump the version if required in Pull Requests](#bumping-the-version-in-pull-requests)
 
 ### Releasing for the next semester
 
 _Also known as a "release freeze"._
 
-The latest stable version of the theme is available on the `master` branch. (This is the default branch selected by the [Jekyll Remote Theme](https://github.com/benbalter/jekyll-remote-theme), the plugin that allows this theme to be used on course websites.) This branch is not changed during semesters at the University of Michigan while courses are in-session. This is to ensure that all project specs throughout the semester have a consistent appearance.
+The latest stable version of the theme is available on the `main` branch. (This is the default branch selected by the [Jekyll Remote Theme](https://github.com/benbalter/jekyll-remote-theme), the plugin that allows this theme to be used on course websites.) This branch is not changed during semesters at the University of Michigan while courses are in-session. This is to ensure that all project specs throughout the semester have a consistent appearance.
 
-The `develop` branch is the default branch for the GitHub repository, and hosts the latest accepted code changes to the theme. This branch is usually ahead of `master`. Between semesters at the University of Michigan, changes from the `develop` branch are merged with `master` to keep them in sync.
+The `develop` branch is the default branch for the GitHub repository, and hosts the latest accepted code changes to the theme. This branch is usually ahead of `main`. Between semesters at the University of Michigan, changes from the `develop` branch are merged with `main` to keep them in sync.
 
-To publish a new release, first prepare the `master` branch and sync with `develop` by initiating the `release` GitHub Actions workflow from the [Actions tab](https://github.com/eecs485staff/primer-spec/actions/workflows/release.yml).
+To publish a new release, first prepare the `main` branch and sync with `develop` by initiating the `release` GitHub Actions workflow from the [Actions tab](https://github.com/eecs485staff/primer-spec/actions/workflows/release.yml).
 
 <details markdown="1">
   <summary>If the GH Actions workflow fails, expand this section for detailed steps.</summary>
@@ -131,14 +131,14 @@ $ pwd
 /users/seshrs/primer-spec
 $ git checkout develop
 $ git pull
-$ git checkout master
+$ git checkout main
 $ git pull
 ```
 
-2. Merge `develop` into `master`. (If you like [signing your commits](https://help.github.com/en/articles/signing-commits), don't forget to add the `-S` flag.)
+2. Merge `develop` into `main`. (If you like [signing your commits](https://help.github.com/en/articles/signing-commits), don't forget to add the `-S` flag.)
 
 ```console
-$ git checkout master
+$ git checkout main
 $ git merge -S develop
 ```
 
@@ -159,7 +159,7 @@ Finally, tag the release:
 
 2. Also specify the upcoming semester after the `+` symbol — this is metadata and is not parsed as part of the version number. (For more about versioning, see [Semver](https://semver.org/).)
 
-3. Click the "Draft a new release" button. Specify the version number. Title and description are optional. _(Switch the "target branch" to `master`. That said, the two branches should be in sync at the time of release so this should not really matter.)_
+3. Click the "Draft a new release" button. Specify the version number. Title and description are optional. _(Switch the "target branch" to `main`. That said, the two branches should be in sync at the time of release so this should not really matter.)_
 
 ### Bumping the version in Pull Requests
 

--- a/docs/DEV_README.md
+++ b/docs/DEV_README.md
@@ -98,9 +98,9 @@ The `script` directory contains various utility scripts for use during developme
 
 ## Stable and Nightly builds
 
-Since the `develop` branch is ahead of the `master` branch [for months at a time](https://github.com/eecs485staff/primer-spec/blob/develop/docs/CONTRIBUTING.md#releasing-for-the-next-semester), Primer Spec deploys to two different websites to preview each branch.
+Since the `develop` branch is ahead of the `main` branch [for months at a time](https://github.com/eecs485staff/primer-spec/blob/develop/docs/CONTRIBUTING.md#releasing-for-the-next-semester), Primer Spec deploys to two different websites to preview each branch.
 
-- The `master` branch hosts the latest stable version, and is deployed via GitHub Pages to https://eecs485staff.github.io/primer-spec/. This site also hosts the CSS and JS assets used by most external Primer Spec pages.
+- The `main` branch hosts the latest stable version, and is deployed via GitHub Pages to https://eecs485staff.github.io/primer-spec/. This site also hosts the CSS and JS assets used by most external Primer Spec pages.
 - The `develop` branch has all the latest changes and is deployed to a private server at https://preview.sesh.rs/previews/eecs485staff/primer-spec/develop-preview/. (This link is also available from the project README page.) It’s automatically updated on every push to the `develop` branch and is rebuilt at least once a month.
 
 Every open PR is also deployed to the private server via [Primer Spec Preview](https://github.com/seshrs/primer-spec-preview) to dynamically interact with proposed changes. The link is made available in a PR comment.
@@ -109,11 +109,11 @@ Every open PR is also deployed to the private server via [Primer Spec Preview](h
 
 See the [CONTRIBUTING docs](https://github.com/eecs485staff/primer-spec/blob/develop/docs/CONTRIBUTING.md#bootstrap-your-local-environment) for actual setup instructions.
 
-Contributing to Primer Spec requires a Ruby environment _and_ a NodeJS environment setup. `script/bootstrap` installs the Ruby dependencies from `Gemfile` and the JS dependencies from `package.json`. The script also installs the pre-commit hook, which ensures that the assets directory is not accidentally modified by commits. (We update the pre-committed JavaScript bundles just before deploying the `master` branch for use by external websites.)
+Contributing to Primer Spec requires a Ruby environment _and_ a NodeJS environment setup. `script/bootstrap` installs the Ruby dependencies from `Gemfile` and the JS dependencies from `package.json`. The script also installs the pre-commit hook, which ensures that the assets directory is not accidentally modified by commits. (We update the pre-committed JavaScript bundles just before deploying the `main` branch for use by external websites.)
 
 For everyday development, use `script/server`, which builds and serves the site at https://localhost:4000. Open the VSCode workspace `primer-spec.code-workspace` and install the recommended extensions for easy ESLint and Prettier formatting.
 
-For every Pull Review and commit to `develop`/`master`, GitHub Actions runs `script/cibuild` to sanity-check that Jekyll can build the website, and also runs linters and any Jest tests. Testing is currently manual — **efforts to improve our automated testing of Primer Spec would be appreciated**.
+For every Pull Review and commit to `develop`/`main`, GitHub Actions runs `script/cibuild` to sanity-check that Jekyll can build the website, and also runs linters and any Jest tests. Testing is currently manual — **efforts to improve our automated testing of Primer Spec would be appreciated**.
 
 ## Versioning & backwards compatibility
 

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -283,7 +283,7 @@ _NOTE:_ A sitemap will only be rendered if your site has multiple pages.
 
 ## Pinning to a specific version
 
-We take care to release new versions of Primer Spec on the `master` branch only between semesters at the University of Michigan. However, if your site needs an even stronger guarantee of stability, you can pin your site to a specific _minor_ version of Primer Spec.
+We take care to release new versions of Primer Spec on the `main` branch only between semesters at the University of Michigan. However, if your site needs an even stronger guarantee of stability, you can pin your site to a specific _minor_ version of Primer Spec.
 
 1. Visit the [Primer Spec Releases](https://github.com/eecs485staff/primer-spec/releases) page. Find the version to which you'd like to pin your site, and note down its title. (For instance, `v1.3.1+fa20`.)
 2. Update your site's `_config.yml` with the version tag from step (1). Specifically, update this line:

--- a/script/cibuild
+++ b/script/cibuild
@@ -8,8 +8,15 @@ bundle exec rubocop -D
 bundle exec script/validate-html
 gem build jekyll-theme-primer-spec.gemspec
 
+# NOTE: The following will be removed after the master branch is removed.
 # On the master branch, check the HTML
 if [ "$(git rev-parse --abbrev-ref HEAD)" = 'master' ]; then
+  bundle exec htmlproofer ./_site --check-html --url-ignore "/web.archive.org/,/localhost/"
+fi
+# NOTE: End of section to delete after master is removed.
+
+# On the main branch, check the HTML
+if [ "$(git rev-parse --abbrev-ref HEAD)" = 'main' ]; then
   bundle exec htmlproofer ./_site --check-html --url-ignore "/web.archive.org/,/localhost/"
 fi
 


### PR DESCRIPTION
As part of #126 (renaming the `master` branch to `main` branch), I set up a new branch called `main`. This PR achieves the following:

1. Keep the new `main` branch in sync with `master` (until `master` has been deleted)
2. All references to `master` in the docs need to be updated.