### PR TITLE
Use contrastive colors for table rows

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -464,13 +464,16 @@ body,
   }
 
   table tr {
+    // Reuse styles for [legacy] code blocks
     @include theme-colors(main-table-pre, #f6f8fa);
+    // But override the background color alone
+    background-color: var(--main-table-bg-color, white);
   }
 
-  // In the original Primer theme, every other row is colored contrastively.
-  // In dark themes, it doesn't look great.
+  // Contrastive coloring for alternate table rows
   table tr:nth-child(2n) {
-    background-color: var(--main-table-pre-bg-color, #f6f8fa);
+    // But override the background color alone
+    background-color: var(--main-table-bg-contrast-color, #f6f8fa);
   }
 
   blockquote {

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -465,6 +465,8 @@ body,
 
   table tr {
     // Reuse styles for [legacy] code blocks
+    color: var(--main-table-pre-text-color, inherit);
+    border-radius: var(--main-table-pre-border-radius, inherit);
     @include theme-colors(main-table-pre, #f6f8fa);
     // But override the background color alone
     background-color: var(--main-table-bg-color, white);

--- a/src_js/subthemes/Subtheme.ts
+++ b/src_js/subthemes/Subtheme.ts
@@ -37,6 +37,8 @@ export const SUBTHEME_VARS = [
   '--tt-border-radius',
   '--main-bg-color',
   '--main-text-color',
+  '--main-table-bg-color',
+  '--main-table-bg-contrast-color',
   '--main-table-pre-bg-color',
   '--main-table-pre-text-color',
   '--main-table-pre-border',

--- a/src_js/subthemes/definitions/common_dark_theme_colors.ts
+++ b/src_js/subthemes/definitions/common_dark_theme_colors.ts
@@ -8,6 +8,8 @@ const BORDER_LINE_COLOR = '#21262d';
 export default {
   '--sidebar-border-color': BORDER_LINE_COLOR,
   '--main-text-color': MAIN_TEXT_COLOR,
+  '--main-table-bg-color': '#0d1117',
+  '--main-table-bg-contrast-color': '#262d36',
   '--main-table-pre-bg-color': CODE_BG_COLOR,
   '--main-table-pre-text-color': CODE_COLOR,
   '--main-table-pre-border': CODE_BORDER,


### PR DESCRIPTION
While attempting to fix dark mode colors in eecs485staff/p5-search-engine#487, I realized that I had removed contrastive table-row styling two years ago. At the time, I didn't know what colors to use for dark mode — that wasn't a great reason to remove contrastive table row styles 😅

Now that GitHub supports dark mode natively, I decided to take a second look. I don't like GitHub's new contrast-color in dark mode, I think it doesn't look visually distinct enough. After playing around with a color picker, I ended up with the following design:

<table>
<tr><th>Light Mode</th><th>Dark Mode</th></tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/12139762/140323634-dda178f6-b369-45e0-befa-bff4d6c02020.png" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/12139762/140323572-a8b989f3-411f-44c9-80d9-d62c4b211c53.png">
</td>
</tr>
</table>

Suggestions are appreciated! CC @bellakiminsun

**NOTE**: I plan to cherry-pick this change to the FA2021 release so that it can be used by EECS 485 P5 this semester.