### PR TITLE
Assign unique anchor ID to codeblockcks with the same title

### DIFF
--- a/demo/enhanced-code-blocks.md
+++ b/demo/enhanced-code-blocks.md
@@ -75,6 +75,7 @@ So long as men can breathe or eyes can see,
 So long lives this and this gives life to thee.
 ```
   ````
+  {: data-title="markdown" }
 </details>
 
 ## Highlighted lines
@@ -131,7 +132,7 @@ So long lives this and this gives life to thee.
 ```
 {: data-highlight="5-8,13" }
 ````
-{: data-highlight="17"}
+{: data-highlight="17" data-title="markdown" }
 
 </details>
 
@@ -187,6 +188,7 @@ x = {
 print(json.dumps(x, indent=4, separators=(". ", " = ")))
 ```
 ````
+{: data-title="markdown" }
 </details>
 <!-- prettier-ignore-end -->
 
@@ -226,7 +228,7 @@ insta485/static/
     └── logo.png
 $ touch insta485/model.py
 ```
-{: data-highlight="1,3,9" }
+{: data-highlight="1,3,9" data-title="markdown" }
   ````
 </details>
 
@@ -271,7 +273,7 @@ def pagerank(M, num_iterations=100, d=0.85):
 ```
 {: data-title="Simplified PageRank implementation" }
   ````
-  {: data-highlight="14" }
+  {: data-highlight="14" data-title="markdown" }
 </details>
 <!-- prettier-ignore-end -->
 
@@ -352,7 +354,7 @@ OCT77770  OCT  77770    # DONT MOVE
 ```
 {: data-title="Apollo 11 memory management" data-highlight="7,13,14,17" }
 ````
-  {: data-highlight="33" }
+  {: data-highlight="33" data-title="markdown" }
 </details>
 <!-- prettier-ignore-end -->
 

--- a/src_js/components/main_content/useEnhancedCodeBlocks.tsx
+++ b/src_js/components/main_content/useEnhancedCodeBlocks.tsx
@@ -128,7 +128,9 @@ function enhanceBlocks(
       }
 
       const title = codeblock.dataset['title'] || null;
-      const anchorId = title ? slugify(title) : null;
+      const anchorId = title
+        ? createCodeBlockAnchorId(codeblockNumericId, title)
+        : null;
 
       const enhancedCodeBlock = createEnhancedCodeBlock(
         codeblockNumericId,
@@ -500,4 +502,11 @@ function selectLines(
   range.setEnd(endNode, endNode.childNodes.length);
   document.getSelection()?.removeAllRanges();
   document.getSelection()?.addRange(range);
+}
+
+function createCodeBlockAnchorId(
+  codeblockNumericId: number,
+  title: string,
+): string {
+  return `${slugify(title)}-${codeblockNumericId}`;
 }


### PR DESCRIPTION
Closes #137.

## Context

Before this PR, Primer Spec would `slugify` the title of the code block to generate an Anchor ID (a hyperlink directly to the code block). Unfortunately, I failed to realize that multiple code blocks on the same page could have the same ID 🤦‍♂️ 

In this PR, we also attach the unique "codeblock ID" to the anchor so that the anchors are guaranteed to be unique.

## Validation

Click the titles of codeblocks in the "Enhanced Code Blocks" demo page in the preview for this PR. Notice that the anchors contain a number referencing the codeblock's ID.

https://preview.sesh.rs/previews/eecs485staff/primer-spec/141/demo/enhanced-code-blocks.html