### PR TITLE
Remove border from inline-code in tables in dark mode

### DIFF
--- a/src_js/subthemes/definitions/common_dark_theme_colors.ts
+++ b/src_js/subthemes/definitions/common_dark_theme_colors.ts
@@ -15,6 +15,7 @@ export default {
   '--main-table-pre-border': CODE_BORDER,
   '--tt-bg-color': 'rgba(240, 246, 252, 0.15)',
   '--tt-text-color': MAIN_TEXT_COLOR,
+  '--tt-border': '0px',
   '--tt-border-radius': '6px',
   // Use the sidebar active color for each theme
   '--sidebar-tt-active-bg-color': 'rgba(0, 0, 0, 0)',


### PR DESCRIPTION
As title. Closes #139.

## Validation

| Before | After |
|-------|---------|
| ![image](https://user-images.githubusercontent.com/12139762/146876140-5d9029da-6a3a-4b57-81d9-408cafd65357.png)  | ![image](https://user-images.githubusercontent.com/12139762/146876038-759f1702-96be-40fa-af42-69383d8f6de1.png) |

I also verified that other inline code blocks look unchanged.