### PR TITLE
[Code blocks][Firefox-specific] Fix dark mode colors on small screens

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -629,6 +629,7 @@ div.primer-spec-callout {
   }
 
   table.highlight {
+    width: 100%;
     margin: 0px;
     border: 0px;
     border-radius: 5px;


### PR DESCRIPTION
I noticed a bug in Firefox when the screen / browser window is "small" and Primer Spec is using a dark mode theme. The issue was that the dark-colored "enhanced code block" wasn't explicitly marked as "full-width". It looks like Chrome uses a more convenient default, whereas Firefox does not.

This PR fixes the colors by making the code block container table as full-width.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="865" alt="Screen Shot 2022-01-10 at 7 53 44 PM" src="https://user-images.githubusercontent.com/12139762/148863206-ff3f6b35-7b3f-40a3-9a6d-9c68b024ca18.png"></td>
<td><img width="867" alt="Screen Shot 2022-01-10 at 7 54 06 PM" src="https://user-images.githubusercontent.com/12139762/148863241-18d42b88-8dc2-4e73-bbdf-c95e8e5fd6cd.png"></td>
</tr>
</table>