### PR TITLE
[Code Blocks] Allow <pre> to contain <code> child

### DIFF
--- a/src_js/components/main_content/useEnhancedCodeBlocks.tsx
+++ b/src_js/components/main_content/useEnhancedCodeBlocks.tsx
@@ -47,7 +47,7 @@ export default function useEnhancedCodeBlocks(
   // Then attempt to enhance ordinary <pre> blocks.
   enhanceBlocks(
     mainElRef.current.querySelectorAll('pre'),
-    (codeblock: HTMLElement) => codeblock.innerHTML.trim(),
+    getRawContentsFromPreCodeblock,
     numCodeBlocks,
   );
 
@@ -88,6 +88,25 @@ function getRawContentsFromJekyllRougeCodeblock(
   }
 
   return (codeEl as HTMLElement).innerHTML;
+}
+
+function getRawContentsFromPreCodeblock(
+  codeblock_: HTMLElement,
+): string | null {
+  let codeblock = codeblock_;
+  // The structure of a <pre> codeblock:
+  // <pre>
+  //   <code> <!-- OPTIONAL -->
+  //     [contents]
+  //   </code>
+  // </pre>
+  if (
+    codeblock.childNodes.length === 1 &&
+    codeblock.firstElementChild?.tagName === 'CODE'
+  ) {
+    codeblock = codeblock.firstElementChild as HTMLElement;
+  }
+  return codeblock.innerHTML.trim();
 }
 
 /**


### PR DESCRIPTION
## Context

While browsing [EECS 183 Project 1](https://eecs183.github.io/p1-recipes/#project-1-style-rubric), I saw the following code block that had a differently-styled first-line:

```html
<pre><code>if (loaves == 1) {
    //do something
} else if (loaves == 2) {
    //do something else
} // and so on</code></pre>
```

I had not anticipated that a manual `<pre>` block might also contain a single `<code>` block child. This commit modifies the code-block detection algorithm to look ignore the inner `<code>` block if applicable.

## Validation

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img width="634" alt="Screen Shot 2022-01-11 at 11 58 42 AM" src="https://user-images.githubusercontent.com/12139762/148990975-ef58f6d1-10b4-4c63-81b5-634fd4c86624.png"></td>
<td><img width="647" alt="Screen Shot 2022-01-11 at 11 58 16 AM" src="https://user-images.githubusercontent.com/12139762/148991018-68b1d839-9894-41b6-b485-89442bc8b99f.png"></td>
</tr>
</table>