### PR TITLE
Retain most HTML elements in heading label in Table of Contents

### DIFF
--- a/index.md
+++ b/index.md
@@ -62,7 +62,7 @@ graph TB
 # Setup
 Follow these steps to get your development environment set up.
 
-### Install the dependencies
+### **_Install_** the dependencies
 First make sure that you have Python 3 installed. If you're on MacOS, you may have to `brew install python3` first.
 
 ```console

--- a/src_js/components/sidebar/TableOfContents.tsx
+++ b/src_js/components/sidebar/TableOfContents.tsx
@@ -187,6 +187,20 @@ function getHeadingLabel(headingNode: HTMLElement): h.JSX.Element {
             );
           } else if (childNode.tagName === 'ABBR') {
             labelComponents.push(<Fragment>{childNode.innerText}</Fragment>);
+          } else if (
+            childNode.tagName === 'A' &&
+            childNode.classList.contains('anchorjs-link')
+          ) {
+            // Skip the AnchorJS link
+            return;
+          } else {
+            // Retain any other HTML elements
+            labelComponents.push(
+              <span
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: childNode.outerHTML }}
+              />,
+            );
           }
           break;
       }


### PR DESCRIPTION
## Context

Fixes #160.

Here's how we generated heading labels in the Table of Contents before this PR: If a heading contained multiple HTML elements (for instance, formatting), we ignored most of those elements and only used text nodes and codeblocks. However, this was a mistake — @marcus-darden pointed out that headings can have italics and other formatting.

This PR updates the heading-label generation logic to preserve almost all formatting within headings (except for the AnchorJS link).

## Validation

I updated the "Install the dependencies" heading in the Project 0 demo spec (`index.md`). Visit the preview URL and observe the label in the sidebar.

Preview URL: https://preview.sesh.rs/previews/eecs485staff/primer-spec/164/

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="538" alt="image" src="https://user-images.githubusercontent.com/12139762/162127043-291aa5f1-4ce8-4dc6-bef7-ed69116c0dd9.png">
</td>
<td>
<img width="552" alt="image" src="https://user-images.githubusercontent.com/12139762/162126934-f4a57702-bc56-430f-9d3c-dd45bcb1a3fa.png">
</td>
</tr>
</table>

---

Thanks for reporting @marcus-darden!

