### PR TITLE
[Code Blocks] `no-line-numbers` variant

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ primerSpec:
 # sitemap: true
 # sitemap:
 #   label: Demo pages
-# useLegacyCodeBlocks: true
+# defaultCodeblockVariant: no-line-numbers
 
 sass:
   style: :compressed

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -89,11 +89,19 @@ version_string: v1.7
                 with `nil` before deciding to use the site-configuration
                 option.
                 {%- endcomment -%}
+                {%- comment -%}
+                `useLegacyCodeBlocks` is DEPRECATED.
+                {%- endcomment -%}
                 {% assign useLegacyCodeBlocks = page.useLegacyCodeBlocks %}
                 {%- if useLegacyCodeBlocks == nil -%}
                 {%- assign useLegacyCodeBlocks = site.primerSpec.useLegacyCodeBlocks -%}
                 {%- endif -%}
                 useLegacyCodeBlocks: {{ useLegacyCodeBlocks | default: false }},
+                {% assign defaultCodeblockVariant = page.defaultCodeblockVariant %}
+                {%- if defaultCodeblockVariant == nil -%}
+                {%- assign defaultCodeblockVariant = site.primerSpec.defaultCodeblockVariant -%}
+                {%- endif -%}
+                defaultCodeblockVariant: "{{ defaultCodeblockVariant | default: 'enhanced' }}"
             };
         </script>
         <script src="{{ base_url }}/assets/{{ layout.version_string }}/js/primer_spec_plugin.min.js" crossorigin="anonymous" defer></script>

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -90,7 +90,7 @@ version_string: v1.7
                 option.
                 {%- endcomment -%}
                 {%- comment -%}
-                `useLegacyCodeBlocks` is DEPRECATED.
+                `useLegacyCodeBlocks` is DEPRECATED starting from v1.7.0
                 {%- endcomment -%}
                 {% assign useLegacyCodeBlocks = page.useLegacyCodeBlocks %}
                 {%- if useLegacyCodeBlocks == nil -%}

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -686,22 +686,25 @@ div.primer-spec-callout {
     }
 
     td.primer-spec-code-block-line-number {
-      width: 1%;
-      min-width: 50px;
-      color: var(--code-block-line-number-color);
-      text-align: right;
-      white-space: nowrap;
-      vertical-align: top;
       cursor: pointer;
       -webkit-user-select: none;
       -moz-user-select: none;
       -ms-user-select: none;
       user-select: none;
-      &::before {
-        content: attr(data-line-number);
-      }
-      &:hover {
-        color: var(--code-block-default-color);
+
+      &.primer-spec-code-block-line-numbers-shown {
+        width: 1%;
+        min-width: 50px;
+        color: var(--code-block-line-number-color);
+        text-align: right;
+        white-space: nowrap;
+        vertical-align: top;
+        &::before {
+          content: attr(data-line-number);
+        }
+        &:hover {
+          color: var(--code-block-default-color);
+        }
       }
     }
 

--- a/demo/enhanced-code-blocks.md
+++ b/demo/enhanced-code-blocks.md
@@ -358,24 +358,20 @@ OCT77770  OCT  77770    # DONT MOVE
 </details>
 <!-- prettier-ignore-end -->
 
-# Legacy Style (Opt Out)
+# Variants
 
-Here's what the "legacy" style code block looks like:
+The default code block style should work for most use cases. However, you might want to show text/code in a different style, for instance, with no line numbers.
 
-<!-- prettier-ignore-start -->
-```console
-$ echo "Spam & Eggs"
-```
-{: data-variant="legacy" }
-<!-- prettier-ignore-end -->
+Primer Spec supports three different styles (aka 'variants') of code blocks:
+- **`enhanced` (default)**: This is the style you've seen in all of the above demos.
+- [**`no-line-numbers`**](#no-line-numbers): Like `enhanced`, but the line numbers are not shown.
+- [**`legacy`**](#legacy): This is the original style of code blocks from the original [GitHub Primer theme](https://github.com/pages-themes/primer).
 
-In my opinion, the legacy style works best with single-line code blocks.
+## Using variants
 
-If you'd like to revert to using the "legacy" style, decide whether you'd like to revert a single code block or all code blocks in the page or in the site.
+### Single code block
 
-## Single code block
-
-Add the attribute `{: data-variant="legacy" }` to the code block. For instance:
+Add the attribute `{: data-variant="<variant>" }` to the code block. For instance:
 
 <!-- prettier-ignore-start -->
 ````markdown
@@ -399,12 +395,64 @@ $ echo "Spam & Eggs"
 ````
 <!-- prettier-ignore-end -->
 
-## Entire page
+### Entire page
 
 Add the page configuration option `defaultCodeblockVariant: legacy` to the top of the page. To learn more about page configuration options, see [USAGE_ADVANCED.md#page-configuration-options](https://github.com/eecs485staff/primer-spec/blob/develop/docs/USAGE_ADVANCED.md#page-configuration-options).
 
 If you have set the [site-wide](#entire-site) configuration option to use legacy code blocks, you can override the setting for a single page by settings `defaultCodeblockVariant: enhanced` at the top of the page.
 
-## Entire site
+### Entire site
 
 Add the site-wide configuration option `defaultCodeblockVariant: legacy` under the `primerSpec` settings in `_config.yml`. To learn more about site configuration options, see [USAGE_ADVANCED.md#site-configuration-options](https://github.com/eecs485staff/primer-spec/blob/develop/docs/USAGE_ADVANCED.md#site-configuration-options).
+
+## Variant Demos
+
+### `no-line-numbers`
+
+Like `enhanced`, but the line numbers are not shown.
+
+<!-- prettier-ignore-start -->
+```plaintext
+On the far-away island of Sala-ma-Sond,
+Yertle the Turtle was king of the pond.
+A nice little pond. It was clean. It was neat.
+The water was warm. There was plenty to eat.
+The turtles had everything turtles might need.
+And they were all happy. Quite happy indeed.
+```
+{: data-variant="no-line-numbers" }
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+<details markdown="1">
+  <summary>Source code for this code block with <code>no-line-numbers</code></summary>
+  
+  ````markdown
+```plaintext
+On the far-away island of Sala-ma-Sond,
+Yertle the Turtle was king of the pond.
+A nice little pond. It was clean. It was neat.
+The water was warm. There was plenty to eat.
+The turtles had everything turtles might need.
+And they were all happy. Quite happy indeed.
+```
+{: data-variant="no-line-numbers" }
+````
+  {: data-highlight="9" data-title="markdown" }
+</details>
+<!-- prettier-ignore-end -->
+
+### `legacy`
+
+This is the original style of code blocks from the original [GitHub Primer theme](https://github.com/pages-themes/primer).
+
+<!-- prettier-ignore-start -->
+```console
+$ echo "Spam & Eggs"
+```
+{: data-variant="legacy" }
+<!-- prettier-ignore-end -->
+
+In my opinion, the legacy style works best with single-line code blocks.
+
+If you'd like to revert to using the "legacy" style, decide whether you'd like to revert a single code block or all code blocks in the page or in the site.

--- a/demo/enhanced-code-blocks.md
+++ b/demo/enhanced-code-blocks.md
@@ -401,10 +401,10 @@ $ echo "Spam & Eggs"
 
 ## Entire page
 
-Add the page configuration option `useLegacyCodeBlocks: true` to the top of the page. To learn more about page configuration options, see [USAGE_ADVANCED.md#page-configuration-options](https://github.com/eecs485staff/primer-spec/blob/develop/docs/USAGE_ADVANCED.md#page-configuration-options).
+Add the page configuration option `defaultCodeblockVariant: legacy` to the top of the page. To learn more about page configuration options, see [USAGE_ADVANCED.md#page-configuration-options](https://github.com/eecs485staff/primer-spec/blob/develop/docs/USAGE_ADVANCED.md#page-configuration-options).
 
-If you have set the [site-wide](#entire-site) configuration option to use legacy code blocks, you can override the setting for a single page by settings `useLegacyCodeBlocks: false` at the top of the page.
+If you have set the [site-wide](#entire-site) configuration option to use legacy code blocks, you can override the setting for a single page by settings `defaultCodeblockVariant: enhanced` at the top of the page.
 
 ## Entire site
 
-Add the site-wide configuration option `useLegacyCodeBlocks: true` under the `primerSpec` settings in `_config.yml`. To learn more about site configuration options, see [USAGE_ADVANCED.md#site-configuration-options](https://github.com/eecs485staff/primer-spec/blob/develop/docs/USAGE_ADVANCED.md#site-configuration-options).
+Add the site-wide configuration option `defaultCodeblockVariant: legacy` under the `primerSpec` settings in `_config.yml`. To learn more about site configuration options, see [USAGE_ADVANCED.md#site-configuration-options](https://github.com/eecs485staff/primer-spec/blob/develop/docs/USAGE_ADVANCED.md#site-configuration-options).

--- a/demo/page-configuration-options.md
+++ b/demo/page-configuration-options.md
@@ -2,7 +2,9 @@
 layout: spec
 
 disableSidebar: true
-useLegacyCodeBlocks: true
+defaultCodeblockVariant: legacy
+# ^ This is equivalent to the following.
+# useLegacyCodeBlocks: true
 ---
 
 # Page Configuration Options
@@ -17,7 +19,7 @@ This boolean indicates whether the sidebar with Table of Contents should be show
 
 This configuration option is useful for small pages, or for pages with few headings. (On such pages, a Sidebar may not be useful, or might hamper the reading experience.)
 
-### `useLegacyCodeBlocks: true`
+### `defaultCodeblockVariant: legacy`
 
 This boolean indicates whether code blocks should _not_ be enhanced on the page. (By default, [code blocks are enhanced](https://eecs485staff.github.io/primer-spec/demo/enhanced-code-blocks.html) by Primer Spec.)
 

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -23,12 +23,12 @@ See the [Primer Spec README](../README.md) for the main usage instructions. This
     - [`latex`: Boolean](#latex-boolean)
     - [`mermaid`: Boolean](#mermaid-boolean)
 - [mermaid: true](#mermaid-true)
-    - [`useLegacyCodeBlocks`: Boolean](#uselegacycodeblocks-boolean)
+    - [`defaultCodeblockVariant`: CodeblockVariant (String)](#defaultcodeblockvariant-codeblockvariant-string)
     - [`excludeFromSitemap`: Boolean](#excludefromsitemap-boolean)
 - [Site configuration options](#site-configuration-options)
     - [`defaultSubthemeName`: String](#defaultsubthemename-string)
     - [`defaultSubthemeMode`: String](#defaultsubthememode-string)
-    - [`useLegacyCodeBlocks`: Boolean](#uselegacycodeblocks-boolean-1)
+    - [`defaultCodeblockVariant`: CodeblockVariant (String)](#defaultcodeblockvariant-codeblockvariant-string-1)
     - [`sitemap`: Boolean | {label: String}](#sitemap-boolean--label-string)
 - [Pinning to a specific version](#pinning-to-a-specific-version)
 - [Using without Jekyll](#using-without-jekyll)
@@ -287,9 +287,14 @@ graph TD;
 
 Check out the [demo](https://eecs485staff.github.io/primer-spec/demo/mermaid-diagrams.html) for inspiration and for links to Mermaid's syntax documentation.
 
-#### `useLegacyCodeBlocks`: Boolean
+#### `defaultCodeblockVariant`: CodeblockVariant (String)
 
-Opt out of ["enhancing" code blocks](#enhanced-code-blocks) on the entire page. See an example of the "legacy" style code block in the [demo](../demo/enhanced-code-blocks.md#legacy-style-opt-out).
+Choose the default codeblock variant to use. Valid codeblock variants are:
+
+- `enhanced` (default)
+- `legacy`
+
+Use `legacy` to opt out of ["enhancing" code blocks](#enhanced-code-blocks) on the entire page. See an example of the "legacy" style code block in the [demo](../demo/enhanced-code-blocks.md#legacy-style-opt-out).
 
 This setting can be overriden per-block.
 
@@ -335,11 +340,16 @@ Specify the default subtheme name. This subtheme will be applied for first-time 
 
 Specify the default subtheme mode. This subtheme will be applied for first-time site visitors. Defaults to `system`.
 
-#### `useLegacyCodeBlocks`: Boolean
+#### `defaultCodeblockVariant`: CodeblockVariant (String)
 
-Opt out of ["enhancing" code blocks](#enhanced-code-blocks) on all pages in the entire site. See an example of the "legacy" style code block in the [demo](../demo/enhanced-code-blocks.md#legacy-style-opt-out).
+Choose the default codeblock variant to use. Valid codeblock variants are:
 
-This setting can be overriden per-page or per-block.
+- `enhanced` (default)
+- `legacy`
+
+Use `legacy` to opt out of ["enhancing" code blocks](#enhanced-code-blocks) on the entire page. See an example of the "legacy" style code block in the [demo](../demo/enhanced-code-blocks.md#legacy-style-opt-out).
+
+This setting can be overriden per-block.
 
 #### `sitemap`: Boolean | {label: String}
 

--- a/src_js/Config.ts
+++ b/src_js/Config.ts
@@ -1,4 +1,5 @@
 import Storage from './utils/Storage';
+import { CodeblockVariant } from './components/main_content/types';
 
 const SUBTHEME_NAME_STORAGE_KEY = 'spec_subtheme_name';
 const SUBTHEME_MODE_STORAGE_KEY = 'spec_subtheme_mode';
@@ -32,6 +33,7 @@ export default {
   SITEMAP_URLS: window.PrimerSpecConfig.sitemapUrls || [],
   SITEMAP_LABEL: window.PrimerSpecConfig.sitemapLabel || 'Supplemental Pages',
   SITEMAP_SITE_TITLE: window.PrimerSpecConfig.sitemapSiteTitle || '',
+  DEFAULT_CODEBLOCK_VARIANT: getDefaultCodeblockVariant(),
   USE_LEGACY_CODE_BLOCKS: window.PrimerSpecConfig.useLegacyCodeBlocks || false,
 
   // Other constants
@@ -71,4 +73,15 @@ function getInitSitemapEnabled() {
   }
 
   return !!window.PrimerSpecConfig.sitemapEnabled;
+}
+
+function getDefaultCodeblockVariant(): CodeblockVariant {
+  if (window.PrimerSpecConfig.useLegacyCodeBlocks === true) {
+    return CodeblockVariant.LEGACY;
+  }
+  const maybeVariant = window.PrimerSpecConfig.defaultCodeblockVariant?.toLowerCase() as CodeblockVariant | null;
+  if (maybeVariant && Object.values(CodeblockVariant).includes(maybeVariant)) {
+    return maybeVariant;
+  }
+  return CodeblockVariant.ENHANCED;
 }

--- a/src_js/Config.ts
+++ b/src_js/Config.ts
@@ -34,7 +34,10 @@ export default {
   SITEMAP_LABEL: window.PrimerSpecConfig.sitemapLabel || 'Supplemental Pages',
   SITEMAP_SITE_TITLE: window.PrimerSpecConfig.sitemapSiteTitle || '',
   DEFAULT_CODEBLOCK_VARIANT: getDefaultCodeblockVariant(),
-  USE_LEGACY_CODE_BLOCKS: window.PrimerSpecConfig.useLegacyCodeBlocks || false,
+
+  // DEPRECATED in v1.7.0. Use `DEFAULT_CODEBLOCK_VARIANT` instead.
+  USE_LEGACY_CODE_BLOCKS_DEPRECATED_DO_NOT_USE:
+    window.PrimerSpecConfig.useLegacyCodeBlocks || false,
 
   // Other constants
   PRIMER_SPEC_APP_NODE_ID: 'primer-spec-app-container',
@@ -77,6 +80,8 @@ function getInitSitemapEnabled() {
 
 function getDefaultCodeblockVariant(): CodeblockVariant {
   if (window.PrimerSpecConfig.useLegacyCodeBlocks === true) {
+    // Note that `useLegacyCodeBlocks` is deprecated in v1.7.0. This code
+    // just ensures backwards-compatibility.
     return CodeblockVariant.LEGACY;
   }
   const maybeVariant = window.PrimerSpecConfig.defaultCodeblockVariant?.toLowerCase() as CodeblockVariant | null;

--- a/src_js/components/main_content/types.ts
+++ b/src_js/components/main_content/types.ts
@@ -1,0 +1,4 @@
+export enum CodeblockVariant {
+  ENHANCED = 'enhanced',
+  LEGACY = 'legacy',
+}

--- a/src_js/components/main_content/types.ts
+++ b/src_js/components/main_content/types.ts
@@ -1,4 +1,5 @@
 export enum CodeblockVariant {
   ENHANCED = 'enhanced',
+  NO_LINE_NUMBERS = 'no-line-numbers',
   LEGACY = 'legacy',
 }

--- a/src_js/components/main_content/useEnhancedCodeBlocks.tsx
+++ b/src_js/components/main_content/useEnhancedCodeBlocks.tsx
@@ -3,8 +3,9 @@ import { RefObject } from 'preact';
 import * as JSXDom from 'jsx-dom';
 import clsx from 'clsx';
 import AnchorJS from 'anchor-js';
-import Config from '../../Config';
 import slugify from '@sindresorhus/slugify';
+import Config from '../../Config';
+import { CodeblockVariant } from './types';
 
 const CODEBLOCK_LINE_CLASS = 'primer-spec-code-block-line-code';
 // We use the following class to ensure that we don't double-process code
@@ -177,13 +178,21 @@ function enhanceBlocks(
 }
 
 function shouldRetainLegacyCodeBlock(codeblock: HTMLElement): boolean {
-  if (codeblock.dataset['variant'] != null) {
-    return codeblock.dataset['variant'] === 'legacy';
-  }
+  // Don't mess with Mermaid blocks, they'll be handled by the Mermaid plugin.
   if (codeblock.querySelector('.language-mermaid') != null) {
     return true;
   }
-  return Config.USE_LEGACY_CODE_BLOCKS;
+  return getCodeblockVariant(codeblock) === CodeblockVariant.LEGACY;
+}
+
+function getCodeblockVariant(codeblock: HTMLElement): CodeblockVariant {
+  const rawVariant = codeblock.dataset[
+    'variant'
+  ]?.toLowerCase() as CodeblockVariant | null;
+  if (rawVariant && Object.values(CodeblockVariant).includes(rawVariant)) {
+    return rawVariant as CodeblockVariant;
+  }
+  return Config.DEFAULT_CODEBLOCK_VARIANT;
 }
 
 function createEnhancedCodeBlock(

--- a/src_js/global.d.ts
+++ b/src_js/global.d.ts
@@ -9,7 +9,7 @@ declare var PrimerSpecConfig: {
   sitemapLabel?: string;
   sitemapEnabled?: boolean;
   sitemapSiteTitle?: string;
-  useLegacyCodeBlocks?: boolean /* DEPRECATED */;
+  useLegacyCodeBlocks?: boolean /* DEPRECATED in v1.7.0 */;
   defaultCodeblockVariant?: string;
 };
 

--- a/src_js/global.d.ts
+++ b/src_js/global.d.ts
@@ -9,7 +9,8 @@ declare var PrimerSpecConfig: {
   sitemapLabel?: string;
   sitemapEnabled?: boolean;
   sitemapSiteTitle?: string;
-  useLegacyCodeBlocks?: boolean;
+  useLegacyCodeBlocks?: boolean /* DEPRECATED */;
+  defaultCodeblockVariant?: string;
 };
 
 // Other global types


### PR DESCRIPTION
## Context
Resolves #159.

@awdeorio noted that line numbers don't work great for all code blocks. (@eecs441staff shared the same feedback with me earlier this year.)

This PR introduces a new code-block "variant" called **`no-line-numbers`**. This variant is exactly identical to `enhanced`, except that line numbers aren't shown. (Other "enhanced" features are retained — copying the block, clicking a line, highlighting lines, etc. continue to work!)

With these changes, the `data-variant` attribute on code blocks supports these three options:
- **`enhanced`** (the default)
- **`no-line-numbers`** (identical to `enhanced` but without line numbers)
- **`legacy`** (the old style)

Additionally, this PR adds a new page-wide/site-wide configuration option `defaultCodeblockVariant` that can be used to set the global default variant!

## Documentation
See the documentation in the demo URL: https://preview.sesh.rs/previews/eecs485staff/primer-spec/165/demo/enhanced-code-blocks.html#no-line-numbers

(After this PR is merged into `main`, the docs will be live at: https://eecs485staff.github.io/primer-spec/165/demo/enhanced-code-blocks.html#no-line-numbers)

## ⚠️ DEPRECATION NOTICE

After this PR, the `useLegacyCodeBlocks` config options are **deprecated**. They will continue to work for now, but may be removed in a future `major` release.

Instead, use `defaultCodeblockVariant` (see the [documentation](#documentation) pages for usage info).

## Validation

Visit the demo at: https://preview.sesh.rs/previews/eecs485staff/primer-spec/165/demo/enhanced-code-blocks.html#no-line-numbers

Notice that the code block looks identical to the `enhanced` variant — hover over the block to see the "copy" button, and click on the left-margin to select lines.

Screenshot:
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/12139762/162887754-15450146-2735-4786-98a5-e18cf26c9d58.png">
