### PR TITLE
[Images] Allow defining light/dark mode variants of images like GitHub

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -789,7 +789,9 @@ $color-mode-opposites: (
     // website creators forget what the exact prefix was.
     img[src$='#gh-#{$color-mode-to-hide}-mode-only'],
     img[src$='#primer-spec-#{$color-mode-to-hide}-mode-only'],
-    img[src$='##{$color-mode-to-hide}-mode-only'],
+    img[src$='##{$color-mode-to-hide}-mode-only'] {
+      display: none;
+    }
     // The :has() selector doesn't work on most browsers yet, but it will
     // some day.
     video:has(source[src$='#gh-#{$color-mode-to-hide}-mode-only']),

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -770,3 +770,24 @@ div.primer-spec-callout {
 .markdown-body img.no-border {
   border: 0px !important;
 }
+
+// Hide dark-mode images in light mode, and vice versa.
+// (This can be used to create the illusion of images that auto-switch between
+// dark and light mode.)
+$color-mode-opposites: (
+  'dark': 'light',
+  'light': 'dark',
+);
+@each $color-mode, $color-mode-to-hide in $color-mode-opposites {
+  :root[data-theme-mode='#{$color-mode}'] .markdown-body {
+    // GitHub only supports this feature with the `gh-` prefix.
+    // The Primer Spec docs recommend using the same directives to match
+    // GitHub, but we also support a couple of other directives in case
+    // website creators forget what the exact prefix was.
+    img[src$='#gh-#{$color-mode-to-hide}-mode-only'],
+    img[src$='#primer-spec-#{$color-mode-to-hide}-mode-only'],
+    img[src$='##{$color-mode-to-hide}-mode-only'] {
+      display: none;
+    }
+  }
+}

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -763,12 +763,15 @@ div.primer-spec-callout {
 .markdown-body img {
   border: 1px solid var(--main-image-border-color);
 }
-.markdown-body.subtheme-mode--dark .invert-colors-in-dark-mode {
-  filter: invert(93%) hue-rotate(180deg);
-  border: 1px solid var(--main-image-border-color-inverted);
-}
 .markdown-body img.no-border {
   border: 0px !important;
+}
+
+// The `invert-colors-in-dark-mode` class technically works on any element,
+// including videos!
+:root[data-theme-mode='dark'] .markdown-body .invert-colors-in-dark-mode {
+  filter: invert(93%) hue-rotate(180deg);
+  border: 1px solid var(--main-image-border-color-inverted);
 }
 
 // Hide dark-mode images in light mode, and vice versa.

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -789,7 +789,12 @@ $color-mode-opposites: (
     // website creators forget what the exact prefix was.
     img[src$='#gh-#{$color-mode-to-hide}-mode-only'],
     img[src$='#primer-spec-#{$color-mode-to-hide}-mode-only'],
-    img[src$='##{$color-mode-to-hide}-mode-only'] {
+    img[src$='##{$color-mode-to-hide}-mode-only'],
+    // The :has() selector doesn't work on most browsers yet, but it will
+    // some day.
+    video:has(source[src$='#gh-#{$color-mode-to-hide}-mode-only']),
+    video:has(source[src$='#primer-spec-#{$color-mode-to-hide}-mode-only']),
+    video:has(source[src$='##{$color-mode-to-hide}-mode-only']) {
       display: none;
     }
   }

--- a/demo/images.md
+++ b/demo/images.md
@@ -5,11 +5,6 @@ layout: spec
 # Images
 {: .primer-spec-toc-ignore }
 
-<video controls style="width: 100%; max-width: 640px; max-height: 480px;">
-  <source src="https://eecs485staff.github.io/p3-insta485-clientside/images/demo-likes.mp4#gh-light-mode-only" type="video/mp4">
-Your browser does not support the video tag.
-</video>
-
 # Basic syntax
 
 Primer Spec automatically adds a subtle `1px` border to images. In my opinion, the border helps with readability, especially for images whose background colors match the background of the page.

--- a/demo/images.md
+++ b/demo/images.md
@@ -141,4 +141,4 @@ While you can use [Mermaid](https://eecs485staff.github.io/primer-spec/demo/merm
 
 After you've created your diagram on Exccalidraw, I recommend exporting it as a PNG *with the scene embedded*. ("Embedding the scene" allows you to reopen the PNG file on Excalidraw in future to make updates!)
 
-Upload the exported PNG image to your Primer Spec website. Then, when you add the image to your page, don't forget to [auto-invert the colors](#auto-invert-colors-in-dark-mode)!
+Upload the exported PNG image to your Primer Spec website. Then, when you add the image to your page, don't forget to [auto-invert the colors](#option-1-recommended-auto-invert-image-colors-in-dark-mode)!

--- a/demo/images.md
+++ b/demo/images.md
@@ -3,8 +3,9 @@ layout: spec
 ---
 
 # Images
+{: .primer-spec-toc-ignore }
 
-## Basic syntax
+# Basic syntax
 
 Primer Spec automatically adds a subtle `1px` border to images. In my opinion, the border helps with readability, especially for images whose background colors match the background of the page.
 
@@ -32,7 +33,7 @@ Equivalent HTML syntax:
 Don't forget the 'alt' text! It's the only way fot visually-impaired users to understand the context provided by the image.
 </div>
 
-## Opt-out of image borders
+# Opt-out of image borders
 
 Simply add the `no-border` class to the image. For instance:
 
@@ -53,7 +54,16 @@ Equivalent HTML syntax:
 </pre>
 </details>
 
-## Auto-invert colors in dark mode
+# Supporting dark mode
+
+Primer Spec supports built-in dark mode themes, which invert the background and foreground colors on the page. Primer Spec is able to invert most colors automatically, but *cannot* automatically handle images on your pages.
+
+You'll need to opt-in to these optimizations to better support your dark mode users. Primer Spec offers you two easy options to add dark mode support for your images:
+
+- [**Option 1 *(recommended)***](#option-1-recommended-auto-invert-image-colors-in-dark-mode): Ask Primer Spec to auto-invert your image!
+- [**Option 2**](#option-2-show-images-only-in-certain-theme-mode): Create two separate images (one optimized for light mode, the other for dark mode)
+
+## Option 1 (recommended): Auto-invert image colors in dark mode
 
 If you add the `invert-colors-in-dark-mode` class to an image, Primer Spec will automatically invert the colors of the image when users view the page in a dark theme!
 
@@ -76,26 +86,56 @@ Equivalent HTML syntax:
 </pre>
 </details>
 
-If you prefer to opt-out of borders, also add the `no-border` class.
+## Option 2: Show images only in certain theme mode
 
-![This image shows a screenshot of Primer Spec in the 'Bella' theme.](https://drive.google.com/uc?export=view&id=1_QPsSGlXKjfqY-3TUbsXej5isOZypK7U){: .invert-colors-in-dark-mode .no-border }
+You can specify that an image is only shown in light mode or dark mode by appending `#gh-dark-mode-only` or `#gh-light-mode-only` to the end of an image URL.
+
+<table>
+<tr><th>Context</th><th>URL</th></tr>
+<tr>
+  <td>Light mode</td>
+  <td>`![Light mode image](./image.png#gh-light-mode-only)`</td>
+</tr>
+<tr>
+  <td>Dark mode</td>
+  <td>`![Dark mode image](./image.png#gh-dark-mode-only)`</td>
+</tr>
+</table>
+
+For instance, I created two different versions of the Primer Spec logo:
+
+<table>
+<tr><th>Light mode</th><th>Dark mode</th></tr>
+<tr>
+  <td><img src="./logo-light.svg" alt="Light mode version of Primer Spec logo" width="250em" class="no-border" /></td>
+  <td><img src="./logo-dark.svg" alt="Dark mode version of Primer Spec logo" width="250em" class="no-border" /></td>
+</tr>
+</table>
+
+However, I only want to show the correct version of the image depending on the theme mode. The following image dynamically displays the correct version of the logo when you change the theme between light and dark modes!
+
+<img src="./logo-light.svg#gh-light-mode-only" alt="Light mode version of Primer Spec logo" width="250em" class="no-border" />
+<img src="./logo-dark.svg#gh-dark-mode-only" alt="Dark mode version of Primer Spec logo" width="250em" class="no-border" />
 
 <details mardown="1">
-<summary>Source code for auto-inverted images</summary>
+<summary>Source code for auto-switching logo</summary>
 
-<pre data-title="Auto-inverted borderless image syntax">
+<pre data-title="Auto-switching logo syntax">
 Markdown syntax:
-![This image shows a screenshot of Primer Spec in the 'Bella' theme.](./screenshot.png){: .invert-colors-in-dark-mode .no-border }
+![Light mode version of Primer Spec logo](./logo-light.svg#gh-light-mode-only)
+![Dark mode version of Primer Spec logo](./logo-dark.svg#gh-dark-mode-only)
 
 Equivalent HTML syntax:
 &lt;img
-  src="./screenshot.png"
-  alt="This image shows a screenshot of Primer Spec in the 'Bella' theme."
-  class="invert-colors-in-dark-mode no-border" /&gt;
+  src="./logo-light.svg#gh-light-mode-only"
+  alt="Light mode version of Primer Spec logo" /&gt;
+&lt;img
+  src="./logo-dark.svg#gh-dark-mode-only"
+  alt="Dark mode version of Primer Spec logo" /&gt;
 </pre>
 </details>
 
-## [Excalidraw](https://excalidraw.com)
+# [Excalidraw](https://excalidraw.com)
 
 While you can use [Mermaid](https://eecs485staff.github.io/primer-spec/demo/mermaid-diagrams.html) to create diagrams, I recommend using [Excalidraw](https://excalidraw.com) for creating free-form diagrams.
 

--- a/demo/images.md
+++ b/demo/images.md
@@ -5,6 +5,11 @@ layout: spec
 # Images
 {: .primer-spec-toc-ignore }
 
+<video controls style="width: 100%; max-width: 640px; max-height: 480px;">
+  <source src="https://eecs485staff.github.io/p3-insta485-clientside/images/demo-likes.mp4#gh-light-mode-only" type="video/mp4">
+Your browser does not support the video tag.
+</video>
+
 # Basic syntax
 
 Primer Spec automatically adds a subtle `1px` border to images. In my opinion, the border helps with readability, especially for images whose background colors match the background of the page.
@@ -94,11 +99,11 @@ You can specify that an image is only shown in light mode or dark mode by append
 <tr><th>Context</th><th>URL</th></tr>
 <tr>
   <td>Light mode</td>
-  <td>`![Light mode image](./image.png#gh-light-mode-only)`</td>
+  <td><code>![Light mode image](./image.png#gh-light-mode-only)</code></td>
 </tr>
 <tr>
   <td>Dark mode</td>
-  <td>`![Dark mode image](./image.png#gh-dark-mode-only)`</td>
+  <td><code>![Dark mode image](./image.png#gh-dark-mode-only)</code></td>
 </tr>
 </table>
 

--- a/docs/MARKDOWN_TIPS.md
+++ b/docs/MARKDOWN_TIPS.md
@@ -141,7 +141,7 @@ If you want to create two different versions of your image, use the [color-mode 
 
 ## Diagrams
 
-Try to use [**Mermaid**](https://eecs485staff.github.io/primer-spec/demo/mermaid.html) for creating diagrams.
+Try to use [**Mermaid**](https://eecs485staff.github.io/primer-spec/demo/mermaid-diagrams.html) for creating diagrams.
 
 If you need a more generic whiteboarding tool, I _strongly_ recommend [**Excalidraw**](https://excalidraw.com). Export the whiteboard as a PNG, then [add the `invert-colors-in-dark-mode` class](#images).
 

--- a/docs/MARKDOWN_TIPS.md
+++ b/docs/MARKDOWN_TIPS.md
@@ -23,6 +23,8 @@ In this guide, I describe what I look for when I add Primer Spec to an existing 
   - [Code block titles](#code-block-titles)
   - [Highlighting lines](#highlighting-lines)
   - [Console blocks (and `pycon`)](#console-blocks-and-pycon)
+- [Images](#images)
+- [Diagrams](#diagrams)
 - [Abbreviations](#abbreviations)
 - [Keyboard shortcuts](#keyboard-shortcuts)
 - [Task Lists (Checklists)](#task-lists-checklists)
@@ -117,6 +119,31 @@ The `console` block also accepts parameters that allow you to customize what cou
 MapTask(input_files=['file01', 'file02'], executable=map.py, output_directory=output)
 ```
 ````
+
+## Images
+
+_Docs: [https://eecs485staff.github.io/primer-spec/demo/images.html](https://eecs485staff.github.io/primer-spec/demo/images.html)_
+
+When possible, try to add the class `invert-colors-in-dark-mode` to your image — Primer Spec will automatically convert your image into dark mode!
+
+```markdown
+![This is my light mode image, but it auto-inverts in dark mode.](./my-image.png){: .invert-colors-in-dark-mode }
+
+OR
+
+<img
+  src="./my-image.png"
+  alt="This is my light mode image, but it auto-inverts in dark mode."
+  class="invert-colors-in-dark-mode" />
+```
+
+If you want to create two different versions of your image, use the [color-mode directives](https://eecs485staff.github.io/primer-spec/demo/images.html#option-2-show-images-only-in-certain-theme-mode) to only display images in a certain color-mode.
+
+## Diagrams
+
+Try to use [**Mermaid**](https://eecs485staff.github.io/primer-spec/demo/mermaid.html) for creating diagrams.
+
+If you need a more generic whiteboarding tool, I _strongly_ recommend [**Excalidraw**](https://excalidraw.com). Export the whiteboard as a PNG, then [add the `invert-colors-in-dark-mode` class](#images).
 
 ## Abbreviations
 

--- a/src_js/components/main_content/index.tsx
+++ b/src_js/components/main_content/index.tsx
@@ -74,7 +74,6 @@ export default function MainContent(props: PropsType): h.JSX.Element {
           props.sidebarShown && !props.isSmallScreen && !is_print_in_progress,
         'primer-spec-content-mobile':
           props.isSmallScreen && !is_print_in_progress,
-        'subtheme-mode--dark': should_use_dark_mode,
       })}
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: props.innerHTML }}

--- a/src_js/subthemes/createSubtheme.ts
+++ b/src_js/subthemes/createSubtheme.ts
@@ -18,6 +18,9 @@ function apply(
   }
 
   RougeThemes[rouge_theme_name].apply();
+
+  // Also reflect the `mode` in the DOM so that CSS can use it.
+  document.documentElement.setAttribute('data-theme-mode', mode);
 }
 
 function reset(


### PR DESCRIPTION
## Context

Closes #163.

GitHub allows users to specify light-mode and dark-mode variants of their image [by appending a directive to the end of the image URL](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to). For instance:

```html
<!-- This image is only shown in light mode -->
<img src="./logo-light.png#gh-light-mode-only" />

<!-- This image is only shown in dark mode -->
<img src="./logo-dark.png#gh-dark-mode-only" />
```

This PR brings the same feature to Primer Spec! I've also updated the docs and demo pages to describe how to optimize your website's images in dark mode.

## Validation

**Demo URL**: https://preview.sesh.rs/previews/eecs485staff/primer-spec/170/demo/images.html#option-2-show-images-only-in-certain-theme-mode

Switch the Primer Spec theme settings between light mode and dark mode. Notice that the light-mode logo is only shown in light mode, and the dark mode logo is shown in dark mode.

https://user-images.githubusercontent.com/12139762/163110306-39781c50-6271-4214-9537-fc43f8d978d1.mov


