### PR TITLE
[Enhanced Codeblocks] Show 'Copy all commands' button for console codeblocks

### DIFF
--- a/demo/enhanced-code-blocks.md
+++ b/demo/enhanced-code-blocks.md
@@ -198,7 +198,7 @@ Console blocks have special handling. Try clicking the line number next to line 
 
 <!-- prettier-ignore-start -->
 ```console
-$ pwd
+$ pwd # prints the current working directory
 /Users/awdeorio/src/eecs485/p2-insta485-serverside
 $ tree insta485/static/
 insta485/static/

--- a/docs/MARKDOWN_TIPS.md
+++ b/docs/MARKDOWN_TIPS.md
@@ -120,6 +120,20 @@ MapTask(input_files=['file01', 'file02'], executable=map.py, output_directory=ou
 ```
 ````
 
+<details markdown="1">
+<summary>Demo of <code>pycon</code> code block</summary>
+
+```console?lang=python&prompt=>>>,...
+>>> from task import MapTask
+>>> task = MapTask(
+...   input_files=["file01", "file02"],
+...   executable="map0.py", output_directory="output")
+>>> task
+MapTask(input_files=['file01', 'file02'], executable=map.py, output_directory=output)
+```
+
+</details>
+
 ## Images
 
 _Docs: [https://eecs485staff.github.io/primer-spec/demo/images.html](https://eecs485staff.github.io/primer-spec/demo/images.html)_


### PR DESCRIPTION
## Context

Closes #169. (Thanks for the feature request @sugihjamin!)

@sugihjamin noted that there is value in copying all *commands* in a `console` code block with a single button. This PR modifies the generic "Copy" button's behavior only in `console` blocks:
- The label says "Copy all commands".
- Clicking it only copies commands (without the command prompt symbols), and skips console output lines.

Here's a screen recording demonstrating what it feels like:

https://user-images.githubusercontent.com/12139762/163686126-d146c7c2-ff2f-4e4e-a5e5-db205d38cc6b.mov

*NOTE: While the functionality works okay for `pycon` blocks, it isn't perfect because it doesn't preserve the whitespace in front of each line. I will open up a separate issue (#175) to track this, but I don't know how to fix it yet.*


## Validation

Visit the demo URL at: https://preview.sesh.rs/previews/eecs485staff/primer-spec/174/demo/enhanced-code-blocks.html#console-example

Scroll to the "Console example", and try clicking the "Copy all commands" button. Paste it into a text file to observe what was copied.

Also sanity-check that other code blocks continue to work as before (copying, click+drag, etc.).