### PR TITLE
[Enhanced code blocks] Make console prompts unselectable

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -741,6 +741,11 @@ div.primer-spec-callout {
   &:hover .primer-spec-zeroclipboard-container {
     opacity: 1;
   }
+
+  // Prevent the console prompts from being selectable.
+  span.primer-spec-code-block-non-selectable {
+    user-select: none;
+  }
 }
 
 .tooltipped:hover,

--- a/src_js/components/main_content/useEnhancedCodeBlocks.tsx
+++ b/src_js/components/main_content/useEnhancedCodeBlocks.tsx
@@ -370,7 +370,11 @@ function createCodeBlockLine(options: {
       const childrenToIncludeInSelection = children.slice(i);
       // (3) Wrap remaining children in a new <span> with id=LC_ID.
       codeLine.innerHTML = '';
-      codeLine.appendChild(<span>{childrenToExcludeFromSelection}</span>);
+      codeLine.appendChild(
+        <span class="primer-spec-code-block-non-selectable">
+          {childrenToExcludeFromSelection}
+        </span>,
+      );
       codeLine.appendChild(
         <span id={LC_ID}>{childrenToIncludeInSelection}</span>,
       );


### PR DESCRIPTION
## Context

In https://github.com/eecs485staff/primer-spec/issues/169#issuecomment-1100118222, @eecs441staff suggested skipping prompts and output when using <kbd>click+drag</kbd> while selecting multiple lines in a console prompt. At the time, I thought it would not be easy to implement given [the limitations of the JS text selection API](https://github.com/eecs485staff/primer-spec/issues/169#issuecomment-1100717425).

I feel a bit silly in retrospect for forgetting to consider the CSS [`user-select`](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select) property 😅 

This PR proposes making the console prompts in enhanced `console` code blocks **completely** unselectable (by clicking line numbers *or* by selecting text the old-fashioned way).

## Demo

Visit the demo URL, and click+drag on the line numbers in the `console` code block.

**Demo URL:** [TODO]

**Screen recording:** 

https://user-images.githubusercontent.com/12139762/164949896-0b7202fe-a8af-4497-a5b2-22a984edf825.mov



## Open question: Should we make console _output_ unselectable?

It's extremely easy to skip the console output too. However, I wonder if students might find it confusing that they have no way to select the console output. Then again, would students ever _need_ to be able to select the output?

CC @awdeorio, @sugihjamin in case you have strong opinions 😃 