### PR TITLE
Do not trim codeblock contents

### DIFF
--- a/src_js/components/main_content/useEnhancedCodeBlocks.tsx
+++ b/src_js/components/main_content/useEnhancedCodeBlocks.tsx
@@ -615,7 +615,7 @@ function createCodeBlockAnchorId(
  * the codeblock.
  *
  * One edge case that this method handles: Lines split within a single span.
- * Consider the following codeblock:
+ * Consider the following codeblock (observe lines 3-4):
  * ```html
  *   <code><span class="c">Line 1</span>
  *   <span class="c">Line 2</span>
@@ -658,5 +658,5 @@ function getCodeblockContents(codeEl: HTMLElement): string {
       resultNode.appendChild(childNode.cloneNode(true));
     }
   });
-  return resultNode.innerHTML.trim();
+  return resultNode.innerHTML;
 }


### PR DESCRIPTION
Fixes #178.

I accidentally introduced the bug described in #178 while zealously trying to remove additional whitespace at the end of codeblocks. In retrospect, Primer Spec shouldn't remove any leading/trailing whitespace in code blocks, the spec authors should be responsible for that!

Thanks @jackphong for reporting the bug!