### PR TITLE
Re-render Mermaid diagrams on window load

### DIFF
--- a/src_js/components/main_content/index.tsx
+++ b/src_js/components/main_content/index.tsx
@@ -8,6 +8,7 @@ import useEnhancedCodeBlocks from './useEnhancedCodeBlocks';
 import useMermaidDiagrams from './useMermaidDiagrams';
 import useTooltippedAbbreviations from './useTooltippedAbbreviations';
 import usePrefersDarkMode from '../../utils/hooks/usePrefersDarkMode';
+import useWindowLoaded from '../../utils/hooks/useWindowLoaded';
 
 type PropsType = {
   innerHTML: string;
@@ -30,8 +31,10 @@ export default function MainContent({
 }: PropsType): h.JSX.Element | null {
   const is_print_in_progress = usePrintInProgress();
   const prefers_dark_mode = usePrefersDarkMode();
+  const window_loaded = useWindowLoaded();
   const main_el_ref = useRef<HTMLElement>(null);
 
+  // INTERACTIVE TASK LIST CHECKBOXES
   const taskListCheckboxEffect = useCallback(useTaskListCheckboxes, [
     innerHTML,
   ]);
@@ -39,6 +42,7 @@ export default function MainContent({
     return taskListCheckboxEffect(main_el_ref);
   }, [taskListCheckboxEffect]);
 
+  // ENHANCED CODE BLOCKS
   const enhancedCodeBlocksEffect = useCallback(useEnhancedCodeBlocks, [
     innerHTML,
   ]);
@@ -46,6 +50,7 @@ export default function MainContent({
     return enhancedCodeBlocksEffect(main_el_ref);
   }, [enhancedCodeBlocksEffect]);
 
+  // MERMAID DIAGRAMS
   let should_use_dark_mode = false;
   switch (currentSubthemeMode) {
     case 'system':
@@ -68,9 +73,20 @@ export default function MainContent({
   }
   const mermaidDiagramsEffect = useCallback(useMermaidDiagrams, [innerHTML]);
   useEffect(() => {
+    // Mermaid Diagrams should only be rendered after the document has
+    // completed loading (including CSS and font resources). Otherwise, labels
+    // may be displayed out of bounds.
+    // Hence, we trigger a re-render of the Mermaid diagrams if the
+    // `window_loaded` variable changes.
+    //
+    // NOTE: We _could_ have delayed rendering till after
+    // `window_loaded === true`, but then users would briefly see a flash with
+    // the original Mermaid source before the diagram is rendered. That page
+    // might also reflow.
     return mermaidDiagramsEffect(main_el_ref, should_use_dark_mode);
-  }, [mermaidDiagramsEffect, should_use_dark_mode]);
+  }, [window_loaded, mermaidDiagramsEffect, should_use_dark_mode]);
 
+  // TOOLTIPPED ABBREVIATIONS
   const tooltippedAbbreviationsEffect = useCallback(
     useTooltippedAbbreviations,
     [innerHTML],
@@ -79,6 +95,7 @@ export default function MainContent({
     return tooltippedAbbreviationsEffect(main_el_ref);
   }, [tooltippedAbbreviationsEffect]);
 
+  // RESET SCROLL POSITION (after closing settings pane)
   useLayoutEffect(() => {
     if (scrollToPosition != null) {
       window.scrollTo(scrollToPosition);

--- a/src_js/utils/hooks/useWindowLoaded.ts
+++ b/src_js/utils/hooks/useWindowLoaded.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'preact/hooks';
+
+/**
+ * Returns a stateful boolean that indicates whether all resources on the page
+ * have been downloaded (and the 'load' event will fire / has fired on the
+ * window).
+ */
+export default function useWindowLoaded(): boolean {
+  const [windowLoaded, setWindowLoaded] = useState(
+    document.readyState === 'complete',
+  );
+  useEffect(() => {
+    const onWindowLoad = () => {
+      setWindowLoaded(true);
+    };
+    window.addEventListener('load', onWindowLoad);
+    return () => {
+      window.removeEventListener('load', onWindowLoad);
+    };
+  });
+  return windowLoaded;
+}


### PR DESCRIPTION
## Context

Closes #187.

While researching potential causes for #187, I found that the MermaidJS documentation suggests rendering diagrams only after the page finishes loading. [(Source)](https://mermaid-js.github.io/mermaid/#/usage?id=labels-out-of-bounds)

It also turns out that the `useEffect` hook fires after the first render _while the JS script is executing_ — however, CSS resources and fonts may not have finishes loading by that time. (More specifically, [`document.readyState`](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState) may be `interactive`.)

This PR makes Primer Spec re-render Mermaid diagrams _again_ after the window "loads". This second re-render should fix any labels that were clipped.

<details>
<summary>Why not skip the first Mermaid render and simply render once the window has loaded?</summary>

The user already begins to see content before the window's `load` event fires. If we only render Mermaid diagrams after the window loads, users will momentarily see the underlying source code for the diagram before it is rendered by Mermaid. The "flashing" behavior may also cause the page's content to reflow / [shift](https://web.dev/cls/).

Here's a screen recording to show what this would look like:

https://user-images.githubusercontent.com/12139762/177217696-802ab6b0-8e18-4f4e-a1c0-57c17c84f146.mov

</details>

## Validation

Follow the reproduction steps of #187 on this PR's preview URL. Verify that the flowchart labels are not cropped on Safari even on the first page load.

Screen recordings:

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/12139762/177218121-27b9ab53-668c-4cf1-bb89-14cd04767528.mov

</td>
<td>

https://user-images.githubusercontent.com/12139762/177218160-ad7a6bba-d183-4027-8021-ceef48127f7e.mov


</td>
</tr>
</table>