### PR TITLE
Convert toggle buttons to real buttons

### DIFF
--- a/src_js/components/common/Hoverable.tsx
+++ b/src_js/components/common/Hoverable.tsx
@@ -1,0 +1,18 @@
+import { h } from 'preact';
+
+type PropsType = {
+  floatRight?: boolean;
+  children: h.JSX.Element | Array<h.JSX.Element>;
+};
+
+export function Hoverable(props: PropsType): h.JSX.Element {
+  return (
+    <span
+      class={`primer-spec-hoverable ${
+        props.floatRight ? 'primer-spec-hoverable-float-right' : ''
+      }`}
+    >
+      {props.children}
+    </span>
+  );
+}

--- a/src_js/components/common/InlineNavButton.tsx
+++ b/src_js/components/common/InlineNavButton.tsx
@@ -4,6 +4,7 @@ import { Hoverable } from './Hoverable';
 
 export type PropsType = {
   icon: IconType;
+  href?: string;
   floatRight?: boolean;
   onClick?: () => void;
   ariaLabel?: string;
@@ -12,8 +13,9 @@ export type PropsType = {
 export default function InlineButton(props: PropsType): h.JSX.Element {
   return (
     <Hoverable floatRight={props.floatRight}>
-      <button
-        class="btn-link primer-spec-hoverable no-print"
+      <a
+        href={props.href ?? '#primer-spec-top'}
+        class="primer-spec-hoverable no-print"
         onClick={
           props.onClick
             ? (event) => {
@@ -25,7 +27,7 @@ export default function InlineButton(props: PropsType): h.JSX.Element {
         aria-label={props.ariaLabel}
       >
         <i class={props.icon} />
-      </button>
+      </a>
     </Hoverable>
   );
 }

--- a/src_js/components/sidebar/index.tsx
+++ b/src_js/components/sidebar/index.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
 } from 'preact/hooks';
 import IconType from '../common/IconType';
+import InlineNavButton from '../common/InlineNavButton';
 import InlineButton from '../common/InlineButton';
 import TableOfContents from './TableOfContents';
 import { usePrintInProgress } from '../../utils/hooks/print';
@@ -109,7 +110,7 @@ export default function Sidebar(props: SidebarProps): h.JSX.Element {
       <h2 class="primer-spec-toc-ignore" id="primer-spec-toc-contents">
         {sitemapUrls == null ? undefined : (
           <Fragment>
-            <InlineButton
+            <InlineNavButton
               icon={IconType.HOME}
               href={sitemapUrls.rootPage.url}
               ariaLabel={sitemapUrls.rootPage.title || 'Home'}


### PR DESCRIPTION
I noticed that the sidebar and settings toggle buttons were anchors instead of real buttons 😅 It’s okay functionally, but is semantically incorrect (they don’t need the `href` attribute). 

This PR updates the toggle buttons to be real `<button>` elements instead of anchors. 