### PR TITLE
Sidebar external and ordered links

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,7 +2,7 @@
 # Set env variable STAGE_STATIC_ASSETS to commit files in frozen versions or
 # JS files in current version.
 
-set -Eueox pipefail
+set -Eueo pipefail
 
 # The following is necessary to resolve symbolic links
 pushd $(dirname $0)
@@ -10,7 +10,7 @@ GITHOOKS_DIR=`pwd -P`
 popd
 PROJECT_ROOT=`dirname $GITHOOKS_DIR`
 
-MINOR_VERSION=$(cat $PROJECT_ROOT/VERSION | grep -o "\d\.\d")
+MINOR_VERSION=$(cat $PROJECT_ROOT/VERSION | grep -o "[[:digit:]]\.[[:digit:]]")
 
 if [[ -z "${STAGE_STATIC_ASSETS:-}" ]]; then
   echo "[pre-commit]: Unstaging assets directory"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 # Set env variable STAGE_STATIC_ASSETS to commit files in frozen versions or
 # JS files in current version.
 
-set -Eueo pipefail
+set -Eueox pipefail
 
 # The following is necessary to resolve symbolic links
 pushd $(dirname $0)

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ report.html
 
 .DS_Store
 .jekyll-cache
+
+*~
+.*~

--- a/_config.yml
+++ b/_config.yml
@@ -19,14 +19,12 @@ primerSpec:
   sitemap:
     label: Docs & Demos
     externalLinks:
+      - title: Wikipedia
+        url: https://www.wikipedia.org/
       - title: "Google" 
         url: https://google.com/
       - title: "EECS 485"
         url: https://eecs485.org
-    order:
-      - "EECS 485"
-      - "[DOCS] Advanced Usage"
-      - "Google"
 
 # defaultCodeblockVariant: no-line-numbers
 

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,16 @@ description: Primer Spec is a Jekyll theme for GitHub Pages
 primerSpec:
   sitemap:
     label: Docs & Demos
+    externalLinks:
+      - title: "Google" 
+        url: https://google.com/
+      - title: "EECS 485"
+        url: https://eecs485.org
+    order:
+      - "EECS 485"
+      - "[DOCS] Advanced Usage"
+      - "Google"
+
 # defaultCodeblockVariant: no-line-numbers
 
 sass:

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -91,7 +91,6 @@ version_string: v1.7
                     {%- for sitePage in site.primerSpec.sitemap.externalLinks -%}
                     {
                         url: '{{ sitePage.url }}',
-                        path: null,
                         external: true,
                         title: '{{ sitePage.title }}',
                     },

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -75,7 +75,6 @@ version_string: v1.7
                     {
                         url: '{{ sitePage.url | relative_url }}',
                         path: '{{ sitePage.path }}',
-                        external: false,
                         {%- if sitePage.title -%}
                         title: '{{ sitePage.title }}',
                         {%- endif -%}

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -78,6 +78,9 @@ version_string: v1.7
                         {%- if sitePage.title -%}
                         title: '{{ sitePage.title }}',
                         {%- endif -%}
+                        {%- if sitePage.sitemapOrder -%}
+                        sitemapOrder: {{ sitePage.sitemapOrder }}
+                        {%- endif -%}
                         {% if sitePage.path == page.path -%}
                         current: true,
                         {%- endif %}
@@ -94,13 +97,6 @@ version_string: v1.7
                     },
                     {%- endfor -%}
                     {%- endif -%}
-                    {%- endif -%}
-                ],
-                sitemapOrder: [
-                    {%- if site.primerSpec.sitemap.order -%}
-                    {%- for title in site.primerSpec.sitemap.order -%}
-                    '{{ title }}',
-                    {%- endfor -%}
                     {%- endif -%}
                 ],
                 sitemapLabel: '{{ site.primerSpec.sitemap.label | default: "" }}',

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -87,15 +87,13 @@ version_string: v1.7
                     },
                     {%- endif -%}
                     {%- endfor -%}
-                    {%- if site.primerSpec.sitemap.externalLinks -%}
                     {%- for sitePage in site.primerSpec.sitemap.externalLinks -%}
                     {
                         url: '{{ sitePage.url }}',
-                        external: true,
                         title: '{{ sitePage.title }}',
+                        external: true,
                     },
                     {%- endfor -%}
-                    {%- endif -%}
                     {%- endif -%}
                 ],
                 sitemapLabel: '{{ site.primerSpec.sitemap.label | default: "" }}',

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -91,7 +91,7 @@ version_string: v1.7
                     {%- for sitePage in site.primerSpec.sitemap.externalLinks -%}
                     {
                         url: '{{ sitePage.url }}',
-                        path: '',
+                        path: null,
                         external: true,
                         title: '{{ sitePage.title }}',
                     },

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -79,7 +79,7 @@ version_string: v1.7
                         title: '{{ sitePage.title }}',
                         {%- endif -%}
                         {%- if sitePage.sitemapOrder -%}
-                        sitemapOrder: {{ sitePage.sitemapOrder }}
+                        sitemapOrder: {{ sitePage.sitemapOrder }},
                         {%- endif -%}
                         {% if sitePage.path == page.path -%}
                         current: true,

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -75,6 +75,7 @@ version_string: v1.7
                     {
                         url: '{{ sitePage.url | relative_url }}',
                         path: '{{ sitePage.path }}',
+                        external: false,
                         {%- if sitePage.title -%}
                         title: '{{ sitePage.title }}',
                         {%- endif -%}
@@ -83,6 +84,23 @@ version_string: v1.7
                         {%- endif %}
                     },
                     {%- endif -%}
+                    {%- endfor -%}
+                    {%- if site.primerSpec.sitemap.externalLinks -%}
+                    {%- for sitePage in site.primerSpec.sitemap.externalLinks -%}
+                    {
+                        url: '{{ sitePage.url }}',
+                        path: '',
+                        external: true,
+                        title: '{{ sitePage.title }}',
+                    },
+                    {%- endfor -%}
+                    {%- endif -%}
+                    {%- endif -%}
+                ],
+                sitemapOrder: [
+                    {%- if site.primerSpec.sitemap.order -%}
+                    {%- for title in site.primerSpec.sitemap.order -%}
+                    '{{ title }}',
                     {%- endfor -%}
                     {%- endif -%}
                 ],

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -199,10 +199,16 @@ $INFO_BORDER_COLOR: rgba(4, 66, 137, 0.2);
     }
   }
 
-  &-sitemap-external {
+  details > &-sitemap-external {
     // Don't include a list item icon for external links.
-    display: inline-flex;
-    align-items: center;
+    // Based on: https://stackoverflow.com/a/66814239
+    & {
+      list-style: none;
+    }
+    &::marker, /* Chrome, Edge, Firefox */ 
+    &::-webkit-details-marker /* Safari */ {
+      display: none;
+    }
 
     i {
       padding-left: 0.3rem;

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -199,6 +199,11 @@ $INFO_BORDER_COLOR: rgba(4, 66, 137, 0.2);
     }
   }
 
+  &-sitemap-external {
+    // Don't include a list item icon for external links.
+    display: inline;
+  }
+
   &-h1 {
     margin-left: auto;
     margin-top: 0.7em;

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -201,7 +201,13 @@ $INFO_BORDER_COLOR: rgba(4, 66, 137, 0.2);
 
   &-sitemap-external {
     // Don't include a list item icon for external links.
-    display: inline;
+    display: inline-flex;
+    align-items: center;
+
+    i {
+      padding-left: 0.3rem;
+      font-size: 0.8rem;
+    }
   }
 
   &-h1 {

--- a/demo/callouts.md
+++ b/demo/callouts.md
@@ -1,5 +1,6 @@
 ---
 layout: spec
+sitemapOrder: 1
 ---
 
 <!-- prettier-ignore-start -->

--- a/docs/DEV_README.md
+++ b/docs/DEV_README.md
@@ -1,6 +1,7 @@
 ---
 layout: spec
 title: '[DOCS] Architecture'
+sitemapOrder: 3
 ---
 
 <!-- prettier-ignore-start -->

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -379,7 +379,7 @@ Use `legacy` to opt out of ["enhancing" code blocks](#enhanced-code-blocks) on t
 
 This setting can be overriden per-block.
 
-#### `sitemap`: Boolean \| {label: String; externalLinks: Array; order: Array}
+#### `sitemap`: Boolean \| {label: String; externalLinks: Array}
 
 _[EECS 280's Project 1](https://eecs280staff.github.io/p1-stats/) has a great example of a sitemap!_
 

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -408,7 +408,7 @@ primerSpec:
   # ... (other site configuration options)
 ```
 
-In this example, all internal pages will appear first in an order based on the individual pages' [`sitemapOrder`](#sitemaporder-number) property. After them will be Title2 followed by Title1.
+In this example, all internal pages will appear first in an order based on the individual pages' [`sitemapOrder`](#sitemaporder-number) property. After them will be Title1 followed by Title2.
 
 To exclude a page from the sitemap, set [`excludeFromSitemap: true`](#excludefromsitemap-boolean) in the front-matter of your page.
 

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -35,7 +35,7 @@ See the [Primer Spec README](../README.md) for the main usage instructions. This
     - [`defaultSubthemeName`: String](#defaultsubthemename-string)
     - [`defaultSubthemeMode`: String](#defaultsubthememode-string)
     - [`defaultCodeblockVariant`: CodeblockVariant (String)](#defaultcodeblockvariant-codeblockvariant-string-1)
-    - [`sitemap`: Boolean \| {label: String}](#sitemap-boolean--label-string)
+    - [`sitemap`: Boolean \| {label: String; externalLinks: Array; order: Array}](#sitemap-boolean--label-string-externallinks-array-order-array)
 - [Pinning to a specific version](#pinning-to-a-specific-version)
 - [Using without Jekyll](#using-without-jekyll)
 
@@ -319,7 +319,7 @@ This setting can be overriden per-block.
 
 #### `excludeFromSitemap`: Boolean
 
-Prevent the page from being displayed as part of the [Sitemap](#sitemap-boolean--label-string) in the Sidebar. This option does not have any effect if the [`sitemap` site-wide configuration option](#sitemap-boolean--label-string) is not set.
+Prevent the page from being displayed as part of the [Sitemap](#sitemap-boolean--label-string-externallinks-array-order-array) in the Sidebar. This option does not have any effect if the [`sitemap` site-wide configuration option](#sitemap-boolean--label-string-externallinks-array-order-array) is not set.
 
 <div class="primer-spec-callout info" markdown="1">
 **NOTE:** If the site-wide option `sitemap` is enabled, then a Sitemap will _not_ be rendered on the page.
@@ -373,13 +373,19 @@ Use `legacy` to opt out of ["enhancing" code blocks](#enhanced-code-blocks) on t
 
 This setting can be overriden per-block.
 
-#### `sitemap`: Boolean \| {label: String}
+#### `sitemap`: Boolean \| {label: String; externalLinks: Array; order: Array}
 
 _[EECS 280's Project 1](https://eecs280staff.github.io/p1-stats/) has a great example of a sitemap!_
 
 If set to `true`, a sitemap will be auto-generated and displayed in the Sidebar of every Primer Spec page with the label _"Supplemental Pages"_.
 
-To customize the label, specify it under a `label` field. Your `_config.yml` would look like this:
+To customize the label, specify it under a `label` field.
+
+To add external links, specify them under an `externalLinks` field. Each item in the `externalLinks` array must have a `title` and a `url` field.
+
+You can also customize the order in which links are displayed. Internal pages must have a `title` specified in the front-matter in order to control the location of their link in the sidebar. All pages *without* a specified order will appear above all pages *with* a specified order. To achieve this, include an `order` field that contains a list of titles for either internal or external pages. Links will be displayed in the same order that you use in the `order` field.
+
+Your `_config.yml` would look like this:
 
 ```yml
 # REQUIRED configuration options, as specified in the Primer Spec README
@@ -390,8 +396,18 @@ remote_theme: eecs485staff/primer-spec
 primerSpec:
   sitemap:
     label: My custom sitemap label
+    externalLinks:
+      - title: Title1
+        url: URL of External Page
+      - title: Title2
+        url: URL of Second External Page
+    order:
+      - Title2
+      - Title1
   # ... (other site configuration options)
 ```
+
+In this example, all internal pages will appear first in the sidebar in an arbitrary order. At the bottom will be Title2 and then Title1.
 
 To exclude a page from the sitemap, set [`excludeFromSitemap: true`](#excludefromsitemap-boolean) in the front-matter of your page.
 

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -1,6 +1,7 @@
 ---
 layout: spec
 title: '[DOCS] Advanced Usage'
+sitemapOrder: 2
 ---
 
 <!-- prettier-ignore-start -->
@@ -27,6 +28,7 @@ See the [Primer Spec README](../README.md) for the main usage instructions. This
 - [Page configuration options](#page-configuration-options)
     - [`disableSidebar`: Boolean](#disablesidebar-boolean)
     - [`hideSidebarOnLoad`: Boolean](#hidesidebaronload-boolean)
+    - [`sitemapOrder`: Number](#sitemaporder-number)
     - [`latex`: Boolean](#latex-boolean)
     - [`mermaid`: Boolean](#mermaid-boolean)
     - [`defaultCodeblockVariant`: CodeblockVariant (String)](#defaultcodeblockvariant-codeblockvariant-string)
@@ -35,7 +37,7 @@ See the [Primer Spec README](../README.md) for the main usage instructions. This
     - [`defaultSubthemeName`: String](#defaultsubthemename-string)
     - [`defaultSubthemeMode`: String](#defaultsubthememode-string)
     - [`defaultCodeblockVariant`: CodeblockVariant (String)](#defaultcodeblockvariant-codeblockvariant-string-1)
-    - [`sitemap`: Boolean \| {label: String; externalLinks: Array; order: Array}](#sitemap-boolean--label-string-externallinks-array-order-array)
+    - [`sitemap`: Boolean \| {label: String; externalLinks: Array}](#sitemap-boolean--label-string-externallinks-array)
 - [Pinning to a specific version](#pinning-to-a-specific-version)
 - [Using without Jekyll](#using-without-jekyll)
 
@@ -245,6 +247,10 @@ Prevent the sidebar (with table of contents) from appearing when a user loads th
 
 Example page: http://eecs485staff.github.io/primer-spec/demo/hide-sidebar-on-load.html
 
+#### `sitemapOrder`: Number
+
+Specify where in the sidebar the link to the page will appear. If unspecified, a page's default `sitemapOrder` is 0. A page with a higher `sitemapOrder` will appear later in the sidebar than page with a lower `sitemapOrder`. You can see each page's `sitemapOrder` property in your browser's dev tools by right-clicking a link in the sidebar and inspecting its `data-order` attribute. External links are treated separately; see the [Sitemap](#sitemap-boolean--label-string-externallinks-array) section for more.
+
 #### `latex`: Boolean
 
 Render Mathematical expressions using [LaTeX syntax and rendering](https://en.wikibooks.org/wiki/LaTeX/Mathematics). Defaults to `false`.
@@ -319,7 +325,7 @@ This setting can be overriden per-block.
 
 #### `excludeFromSitemap`: Boolean
 
-Prevent the page from being displayed as part of the [Sitemap](#sitemap-boolean--label-string-externallinks-array-order-array) in the Sidebar. This option does not have any effect if the [`sitemap` site-wide configuration option](#sitemap-boolean--label-string-externallinks-array-order-array) is not set.
+Prevent the page from being displayed as part of the [Sitemap](#sitemap-boolean--label-string-externallinks-array) in the Sidebar. This option does not have any effect if the [`sitemap` site-wide configuration option](#sitemap-boolean--label-string-externallinks-array) is not set.
 
 <div class="primer-spec-callout info" markdown="1">
 **NOTE:** If the site-wide option `sitemap` is enabled, then a Sitemap will _not_ be rendered on the page.
@@ -381,9 +387,7 @@ If set to `true`, a sitemap will be auto-generated and displayed in the Sidebar 
 
 To customize the label, specify it under a `label` field.
 
-To add external links, specify them under an `externalLinks` field. Each item in the `externalLinks` array must have a `title` and a `url` field.
-
-You can also customize the order in which links are displayed. Internal pages must have a `title` specified in the front-matter in order to control the location of their link in the sidebar. All pages *without* a specified order will appear above all pages *with* a specified order. To achieve this, include an `order` field that contains a list of titles for either internal or external pages. Links will be displayed in the same order that you use in the `order` field.
+To add external links, specify them under an `externalLinks` field. Each item in the `externalLinks` array must have a `title` and a `url` field. External links will always appear at the bottom of the sidebar, below all internal links. They will appear in the same order that you include them in your `_config.yml`.
 
 Your `_config.yml` would look like this:
 
@@ -401,9 +405,6 @@ primerSpec:
         url: URL of External Page
       - title: Title2
         url: URL of Second External Page
-    order:
-      - Title2
-      - Title1
   # ... (other site configuration options)
 ```
 

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -408,7 +408,7 @@ primerSpec:
   # ... (other site configuration options)
 ```
 
-In this example, all internal pages will appear first in the sidebar in an arbitrary order. At the bottom will be Title2 and then Title1.
+In this example, all internal pages will appear first in an order based on the individual pages' [`sitemapOrder`](#sitemaporder-number) property. After them will be Title2 followed by Title1.
 
 To exclude a page from the sitemap, set [`excludeFromSitemap: true`](#excludefromsitemap-boolean) in the front-matter of your page.
 

--- a/src_js/Config.ts
+++ b/src_js/Config.ts
@@ -31,6 +31,7 @@ export default {
   INIT_SUBTHEME_MODE,
   INIT_SITEMAP_ENABLED,
   SITEMAP_URLS: window.PrimerSpecConfig.sitemapUrls || [],
+  SITEMAP_URL_ORDER: window.PrimerSpecConfig.sitemapOrder || [],
   SITEMAP_LABEL: window.PrimerSpecConfig.sitemapLabel || 'Supplemental Pages',
   SITEMAP_SITE_TITLE: window.PrimerSpecConfig.sitemapSiteTitle || '',
   DEFAULT_CODEBLOCK_VARIANT: getDefaultCodeblockVariant(),

--- a/src_js/Config.ts
+++ b/src_js/Config.ts
@@ -31,7 +31,6 @@ export default {
   INIT_SUBTHEME_MODE,
   INIT_SITEMAP_ENABLED,
   SITEMAP_URLS: window.PrimerSpecConfig.sitemapUrls || [],
-  SITEMAP_URL_ORDER: window.PrimerSpecConfig.sitemapOrder || [],
   SITEMAP_LABEL: window.PrimerSpecConfig.sitemapLabel || 'Supplemental Pages',
   SITEMAP_SITE_TITLE: window.PrimerSpecConfig.sitemapSiteTitle || '',
   DEFAULT_CODEBLOCK_VARIANT: getDefaultCodeblockVariant(),

--- a/src_js/components/common/IconType.ts
+++ b/src_js/components/common/IconType.ts
@@ -3,5 +3,6 @@ enum IconType {
   HOME = 'fas fa-home',
   SETTINGS = 'fas fa-cog',
   SIDEBAR = 'fas fa-bars',
+  EXTERNAL_LINK = 'fas fa-external-link-alt',
 }
 export default IconType;

--- a/src_js/components/sidebar/SidebarContent.tsx
+++ b/src_js/components/sidebar/SidebarContent.tsx
@@ -45,7 +45,7 @@ function SitemapPage(props: {
   children: h.JSX.Element | undefined;
 }): h.JSX.Element {
   const title =
-    props.page.title || (props.page.path && getSitemapName(props.page.path!));
+    props.page.title || (props.page.path && getSitemapName(props.page.path));
   if (!title) {
     console.error(
       `Primer Spec: Page with URL ${props.page.url} has no title to display in sidebar`,

--- a/src_js/components/sidebar/SidebarContent.tsx
+++ b/src_js/components/sidebar/SidebarContent.tsx
@@ -47,8 +47,8 @@ function SitemapPage(props: {
   const title =
     props.page.title || (props.page.path && getSitemapName(props.page.path!));
   if (!title) {
-    console.log(
-      `Warning: Page with URL ${props.page.url} has no title to display in sidebar`,
+    console.error(
+      `Primer Spec: Page with URL ${props.page.url} has no title to display in sidebar`,
     );
   }
   if (props.page.current) {

--- a/src_js/components/sidebar/SidebarContent.tsx
+++ b/src_js/components/sidebar/SidebarContent.tsx
@@ -44,7 +44,13 @@ function SitemapPage(props: {
   dedent?: boolean;
   children: h.JSX.Element | undefined;
 }): h.JSX.Element {
-  const title = props.page.title || getSitemapName(props.page.path!);
+  const title =
+    props.page.title || (props.page.path && getSitemapName(props.page.path!));
+  if (!title) {
+    console.log(
+      `Warning: Page with URL ${props.page.url} has no title to display in sidebar`,
+    );
+  }
   if (props.page.current) {
     return (
       <details

--- a/src_js/components/sidebar/SidebarContent.tsx
+++ b/src_js/components/sidebar/SidebarContent.tsx
@@ -65,13 +65,20 @@ function SitemapPage(props: {
       <details class={props.dedent ? '' : 'primer-spec-toc-sitemap-item'}>
         <summary
           class={props.page.external ? 'primer-spec-toc-sitemap-external' : ''}
+          data-order={props.page.external ? '' : props.page.sitemapOrder || 0}
           role="link"
           onClick={(e) => {
             e.preventDefault();
             window.location.href = props.page.url;
           }}
         >
-          {props.page.external && <i class={IconType.EXTERNAL_LINK} />} {title}
+          {title}
+          {props.page.external && (
+            <Fragment>
+              <i class={IconType.EXTERNAL_LINK} />
+              <span class="sr-only">External Link</span>
+            </Fragment>
+          )}
         </summary>
       </details>
     </a>

--- a/src_js/components/sidebar/SidebarContent.tsx
+++ b/src_js/components/sidebar/SidebarContent.tsx
@@ -25,8 +25,8 @@ export default function SidebarContent(props: PropsType): h.JSX.Element {
         open={props.sitemap.rootPage.current ? undefined : true}
       >
         <summary>{Config.SITEMAP_LABEL}</summary>
-        {props.sitemap.siteUrls.map((sitePage) => (
-          <SitemapPage key={sitePage.path} page={sitePage}>
+        {props.sitemap.siteUrls.map((sitePage, i) => (
+          <SitemapPage key={sitePage.url} page={sitePage}>
             {sitePage.current ? props.children : undefined}
           </SitemapPage>
         ))}

--- a/src_js/components/sidebar/SidebarContent.tsx
+++ b/src_js/components/sidebar/SidebarContent.tsx
@@ -44,7 +44,7 @@ function SitemapPage(props: {
   dedent?: boolean;
   children: h.JSX.Element | undefined;
 }): h.JSX.Element {
-  const title = props.page.title || getSitemapName(props.page.path);
+  const title = props.page.title || getSitemapName(props.page.path!);
   if (props.page.current) {
     return (
       <details

--- a/src_js/components/sidebar/SidebarContent.tsx
+++ b/src_js/components/sidebar/SidebarContent.tsx
@@ -25,7 +25,7 @@ export default function SidebarContent(props: PropsType): h.JSX.Element {
         open={props.sitemap.rootPage.current ? undefined : true}
       >
         <summary>{Config.SITEMAP_LABEL}</summary>
-        {props.sitemap.siteUrls.map((sitePage, i) => (
+        {props.sitemap.siteUrls.map((sitePage) => (
           <SitemapPage key={sitePage.url} page={sitePage}>
             {sitePage.current ? props.children : undefined}
           </SitemapPage>

--- a/src_js/components/sidebar/SidebarContent.tsx
+++ b/src_js/components/sidebar/SidebarContent.tsx
@@ -2,6 +2,8 @@ import { h, Fragment } from 'preact';
 import Config from '../../Config';
 import getSitemapName from './getSitemapName';
 
+import IconType from '../common/IconType';
+
 import type { SitemapType } from './getSitemapUrls';
 
 type PropsType = { sitemap?: null | SitemapType; children: h.JSX.Element };
@@ -62,13 +64,14 @@ function SitemapPage(props: {
     <a href={props.page.url} tabIndex={-1}>
       <details class={props.dedent ? '' : 'primer-spec-toc-sitemap-item'}>
         <summary
+          class={props.page.external ? 'primer-spec-toc-sitemap-external' : ''}
           role="link"
           onClick={(e) => {
             e.preventDefault();
             window.location.href = props.page.url;
           }}
         >
-          {title}
+          {props.page.external && <i class={IconType.EXTERNAL_LINK} />} {title}
         </summary>
       </details>
     </a>

--- a/src_js/components/sidebar/getSitemapUrls.ts
+++ b/src_js/components/sidebar/getSitemapUrls.ts
@@ -43,24 +43,18 @@ export default function getSitemapUrls(
   rootPage.title = Config.SITEMAP_SITE_TITLE;
 
   siteUrls.sort((lhs, rhs) => {
-    const lhsIndex = Config.SITEMAP_URL_ORDER.findIndex(
-      (item) => item === lhs.title,
-    );
-    const rhsIndex = Config.SITEMAP_URL_ORDER.findIndex(
-      (item) => item === rhs.title,
-    );
-    if (lhsIndex === -1) {
-      // If lhs's order isn't specified, it should come before all items
-      // with order specified.
-      return -1;
-    } else if (rhsIndex === -1) {
-      // If rhs's order isn't specified but lhs's order is, then we know rhs
-      // should be placed before lhs.
+    const lhsOrder = lhs.sitemapOrder || 0;
+    const rhsOrder = rhs.sitemapOrder || 0;
+    if (lhs.external) {
+      // If lhs is external, it should come after all internal links.
       return 1;
+    } else if (rhs.external) {
+      // If rhs is external but not lhs, then rhs should come after lhs.
+      return -1;
     }
-    // If both items' order is specified, sort them based on whose title has a
-    // lower index in the ordering list.
-    return lhsIndex - rhsIndex;
+    // If both items are internal, sort them based on which one's sitemapOrder
+    // property is lower.
+    return lhsOrder - rhsOrder;
   });
 
   return { rootPage, siteUrls };

--- a/src_js/components/sidebar/getSitemapUrls.ts
+++ b/src_js/components/sidebar/getSitemapUrls.ts
@@ -43,15 +43,20 @@ export default function getSitemapUrls(
   rootPage.title = Config.SITEMAP_SITE_TITLE;
 
   siteUrls.sort((lhs, rhs) => {
-    const lhsOrder = lhs.sitemapOrder || 0;
-    const rhsOrder = rhs.sitemapOrder || 0;
-    if (lhs.external) {
+    if (lhs.external && rhs.external) {
+      // If both links are external, preserve the order that they are declared
+      // in.
+      return 0;
+    } else if (lhs.external) {
       // If lhs is external, it should come after all internal links.
       return 1;
     } else if (rhs.external) {
       // If rhs is external but not lhs, then rhs should come after lhs.
       return -1;
     }
+
+    const lhsOrder = lhs.sitemapOrder || 0;
+    const rhsOrder = rhs.sitemapOrder || 0;
     // If both items are internal, sort them based on which one's sitemapOrder
     // property is lower.
     return lhsOrder - rhsOrder;

--- a/src_js/components/sidebar/getSitemapUrls.ts
+++ b/src_js/components/sidebar/getSitemapUrls.ts
@@ -42,5 +42,26 @@ export default function getSitemapUrls(
   const [rootPage] = siteUrls.splice(rootIndex, 1);
   rootPage.title = Config.SITEMAP_SITE_TITLE;
 
+  siteUrls.sort((lhs, rhs) => {
+    const lhsIndex = Config.SITEMAP_URL_ORDER.findIndex(
+      (item) => item === lhs.title,
+    );
+    const rhsIndex = Config.SITEMAP_URL_ORDER.findIndex(
+      (item) => item === rhs.title,
+    );
+    if (lhsIndex === -1) {
+      // If lhs's order isn't specified, it should come before all items
+      // with order specified.
+      return -1;
+    } else if (rhsIndex === -1) {
+      // If rhs's order isn't specified but lhs's order is, then we know rhs
+      // should be placed before lhs.
+      return 1;
+    }
+    // If both items' order is specified, sort them based on whose title has a
+    // lower index in the ordering list.
+    return lhsIndex - rhsIndex;
+  });
+
   return { rootPage, siteUrls };
 }

--- a/src_js/components/sidebar/getSitemapUrls.ts
+++ b/src_js/components/sidebar/getSitemapUrls.ts
@@ -22,7 +22,7 @@ export default function getSitemapUrls(
 
   // Remove assets pages
   const siteUrls = Config.SITEMAP_URLS.filter(
-    (pageInfo) => !pageInfo.path.startsWith('assets'),
+    (pageInfo) => !pageInfo.path?.startsWith('assets'),
   );
 
   if (siteUrls.length === 0) {
@@ -30,7 +30,7 @@ export default function getSitemapUrls(
   }
 
   const rootIndex = siteUrls.findIndex((page) =>
-    /^(index|readme)\.(md|htm|html)$/.test(page.path.toLowerCase()),
+    /^(index|readme)\.(md|htm|html)$/.test(page.path?.toLowerCase() || ''),
   );
   if (rootIndex === -1) {
     console.warn(

--- a/src_js/global.d.ts
+++ b/src_js/global.d.ts
@@ -23,7 +23,7 @@ declare type SubthemeSelectionType = {
 
 declare type SitemapPageInfoType = {
   url: string;
-  path: string;
+  path?: string;
   external?: boolean;
   sitemapOrder?: number;
   title?: string;

--- a/src_js/global.d.ts
+++ b/src_js/global.d.ts
@@ -25,7 +25,7 @@ declare type SubthemeSelectionType = {
 declare type SitemapPageInfoType = {
   url: string;
   path: string;
-  external: boolean;
+  external?: boolean;
   title?: string;
   current?: boolean;
 };

--- a/src_js/global.d.ts
+++ b/src_js/global.d.ts
@@ -6,7 +6,6 @@ declare var PrimerSpecConfig: {
   defaultSubthemeName?: string;
   defaultSubthemeMode?: string;
   sitemapUrls?: Array<SitemapPageInfoType>;
-  sitemapOrder?: Array<string>;
   sitemapLabel?: string;
   sitemapEnabled?: boolean;
   sitemapSiteTitle?: string;
@@ -26,6 +25,7 @@ declare type SitemapPageInfoType = {
   url: string;
   path: string;
   external?: boolean;
+  sitemapOrder?: number;
   title?: string;
   current?: boolean;
 };

--- a/src_js/global.d.ts
+++ b/src_js/global.d.ts
@@ -6,6 +6,7 @@ declare var PrimerSpecConfig: {
   defaultSubthemeName?: string;
   defaultSubthemeMode?: string;
   sitemapUrls?: Array<SitemapPageInfoType>;
+  sitemapOrder?: Array<string>;
   sitemapLabel?: string;
   sitemapEnabled?: boolean;
   sitemapSiteTitle?: string;
@@ -24,6 +25,7 @@ declare type SubthemeSelectionType = {
 declare type SitemapPageInfoType = {
   url: string;
   path: string;
+  external: boolean;
   title?: string;
   current?: boolean;
 };


### PR DESCRIPTION
Replacement for #194.

Closes #186. I wasn't able to test this very effectively because of #191, but hopefully it all makes sense! I edited _config.yml to include some external links and manipulate the order just for demo purposes: that should be reverted before merging this, if you decide to merge it.

@seshrs and I began a discussion in #194 at [this comment](https://github.com/eecs485staff/primer-spec/pull/194#discussion_r916418872) about what the best way would be to allow changing the order of pages in the sidebar.