### PR TITLE
Change `base_url` to empty string

### DIFF
--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -21,7 +21,7 @@ version_string: v1.7
         {%- endif %}
 
         {%- if jekyll.environment == "dev" %}
-            {% assign base_url = "http://localhost:4000" %}
+            {% assign base_url = "" %}
         {% elsif jekyll.environment == "site-preview" %}   
             {% assign base_url = site.url | append: site.baseurl %}
         {% else %}


### PR DESCRIPTION
Closes #191. There's some issue caused by setting the base URL to localhost:8000 on some machines, but this is fixed by simply setting the base URL to the empty string, since in development mode URLs can start from `/`.