### PR TITLE
[Enhanced Code Blocks] Fix multi-line console command copy behavior

### DIFF
--- a/src_js/components/main_content/useEnhancedCodeBlocks.tsx
+++ b/src_js/components/main_content/useEnhancedCodeBlocks.tsx
@@ -451,6 +451,9 @@ const CONSOLE_COPY_LINES_MAP_FN = (
   }
   // (2) If there's a console prompt, skip it
   const LC_ID = `${codeblock.id}-LC${lineNumber}`;
+  if (line.id === LC_ID) {
+    return line.innerText;
+  }
   const lineText = line.querySelector(`#${LC_ID}`) as HTMLElement | null;
   return lineText?.innerText;
 };


### PR DESCRIPTION
## Context

Closes #183.

<details>
<summary>Further technical context</summary>

In #174, I modified the "Copy code" button of enhanced code blocks to instead "Copy all commands". The button would then only copy the code block lines that were not output. It would also skip the console prompt (the `$` symbol) if present in the line.

However, my code to skip the console prompt had a bug: It assumed that console commands would be wrapped in an element inside the HTML element representing the line — this is only true for lines with console prompts!

In other words, my code would only copy enhanced code block lines of this format:
```html
<!-- This line contains a command prompt. -->
<td id="" class="primer-spec-code-block-line-code">
  <span>
    <span class="gp">$</span>
    <span class="w"> </span>
  </span>
  <!-- The next line is the command text to be copied. Notice that the ID is *inside* the TD element, that's how we know it's the text to be copied -->
  <span id="primer-spec-code-block-0-LC1">mapreduce-manager</span>
</td>
```

But would ignore lines of this form:
```html
<!-- This line does not contain a command prompt, but contains a console command -->
<!-- Notice that the line HAS the ID because all of the text refers to a console command -->
<td id="primer-spec-code-block-0-LC2" class="primer-spec-code-block-line-code">
  <span class="nt">--host</span> localhost
</td>
```
</details>

## Validation

I temporarily added a new console block to `index.md`:
````markdown
```console
$ mapreduce-manager \
    --host localhost \
    --port 6000 \
    --hb-port 5999 \
    --log-file mapreduce-manager.log &
mock command output text
```
````

Then I rendered the page with the changes in the PR and clicked the "Copy all commands" button. The entire command was copied, and the console prompt and output text were not copied.