### PR TITLE
[Enhanced Code Blocks] Ignore all console prompts when copying commands

### DIFF
--- a/demo/enhanced-code-blocks.md
+++ b/demo/enhanced-code-blocks.md
@@ -207,6 +207,12 @@ insta485/static/
 └── images
     └── logo.png
 $ touch insta485/model.py
+$ mapreduce-manager \
+    --host localhost \
+    --port 6000 \
+    --hb-port 5999 \
+    --log-file mapreduce-manager.log &
+Error: Not implemented
 ```
 {: data-highlight="1,3,9" }
 <!-- prettier-ignore-end -->
@@ -227,8 +233,42 @@ insta485/static/
 └── images
     └── logo.png
 $ touch insta485/model.py
+$ mapreduce-manager \
+    --host localhost \
+    --port 6000 \
+    --hb-port 5999 \
+    --log-file mapreduce-manager.log &
+Error: Not implemented
 ```
 {: data-highlight="1,3,9" data-title="markdown" }
+  ````
+</details>
+
+## `pycon` console example
+
+Although `pycon` ("Python Console") isn't a supported "language" by the syntax-highlighter, you can emulate its behavior by specifying parameters to the `console` syntax highlighter:
+
+```console?lang=python&prompt=>>>,...
+>>> from task import MapTask
+>>> task = MapTask(
+...   input_files=["file01", "file02"],
+...   executable="map0.py", output_directory="output")
+>>> task
+MapTask(input_files=['file01', 'file02'], executable=map.py, output_directory=output)
+```
+
+<details markdown="1">
+  <summary>Source code for this <code>pycon</code> code block</summary>
+  
+  ````markdown
+```console?lang=python&prompt=>>>,...
+>>> from task import MapTask
+>>> task = MapTask(
+...   input_files=["file01", "file02"],
+...   executable="map0.py", output_directory="output")
+>>> task
+MapTask(input_files=['file01', 'file02'], executable=map.py, output_directory=output)
+```
   ````
 </details>
 


### PR DESCRIPTION
## Context

Closes #175.

While working on #199, it occurred to me that I could solve #175 (whitespace support while copying `pycon` commands) in a similar fashion.

Before this PR, I used the same logic used by the line-number click handler to figure out which text contained the console prompt and which was the actual code. However, the "copy commands" button's logic does not need to be tied to the implementation details of the line-number click handler.

This PR updates the console-copy command to manually remove console prompts (and a single trailing whitespace) from each line.

## Validation

Visit the preview URL at: https://preview.sesh.rs/previews/eecs485staff/primer-spec/200/demo/enhanced-code-blocks.html#pycon-console-example

I've modified the existing console example and added a new `pycon` example with this code:
````markdown
```console?lang=python&prompt=>>>,...
>>> from task import MapTask
>>> task = MapTask(
...   input_files=["file01", "file02"],
...   executable="map0.py", output_directory="output")
>>> task
MapTask(input_files=['file01', 'file02'], executable=map.py, output_directory=output)
```
````

Try clicking the "Copy all commands" button. It should correctly copy the entire Python snippet while ignoring output and prompts, while also removing the trailing whitespace after each console prompt.