### PR TITLE
Resizable sidebar

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -17,6 +17,7 @@ $TOPBAR_HEIGHT: $ICON_FONT_SIZE * 2;
 $Z_INDEX_SETTINGS: 2;
 $Z_INDEX_TOPBAR: 3;
 $Z_INDEX_SIDEBAR: 4;
+$Z_INDEX_SIDEBAR_RESIZE_HANDLE: 5;
 
 $INFO_BG_COLOR: #dbedff;
 $INFO_BORDER_COLOR: rgba(4, 66, 137, 0.2);
@@ -33,6 +34,7 @@ $INFO_BORDER_COLOR: rgba(4, 66, 137, 0.2);
 
 .primer-spec-sidebar {
   width: $SIDEBAR_WIDTH;
+  box-sizing: border-box;
   padding-left: 1em;
   height: 100%;
   overflow: auto;
@@ -104,6 +106,23 @@ $INFO_BORDER_COLOR: rgba(4, 66, 137, 0.2);
 
     .external-icon {
       font-size: 80%;
+    }
+  }
+
+  // RESIZABLE SIDEBAR
+
+  &-resize-handle {
+    height: 100%;
+    left: $SIDEBAR_WIDTH;
+    width: 10px;
+    cursor: col-resize;
+    -webkit-touch-callout: none;
+    user-select: none;
+    z-index: $Z_INDEX_SIDEBAR_RESIZE_HANDLE;
+
+    &:hover,
+    &:active {
+      border-left: 1px double lightblue;
     }
   }
 }

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -122,7 +122,7 @@ $INFO_BORDER_COLOR: rgba(4, 66, 137, 0.2);
 
     &:hover,
     &:active {
-      border-left: 1px double lightblue;
+      border-left: 1px double var(--sidebar-resize-handle);
     }
   }
 }

--- a/_sass/spec/default_theme.scss
+++ b/_sass/spec/default_theme.scss
@@ -15,6 +15,8 @@
   --sidebar-active-toc-h2-section-link-color: #0366d6;
   --sidebar-toc-section-link-color: black;
 
+  --sidebar-resize-handle: #ccc;
+
   --main-heading-link-color: #0366d6;
   --main-link-color: #0366d6;
   --tt-border-radius: 3px;

--- a/index.md
+++ b/index.md
@@ -114,7 +114,7 @@ Our sidebar is `fixed` to the page with a constant width (we used `18em`), heigh
 
 We recommend placing any CSS style definitions you need in `spec.css`.
 
-##### Do I have to hard-code _all_ the headings in the page?
+#### Do I have to hard-code _all_ the headings in the page?
 No, but it's a good idea to hard-code at least some of them, and randomly hard-code some other items in the sidebar. In particular, make sure to have a mix of heading indentations in your sidebar — consider styling each header level differently.
 
 When you style the various header levels, remember that you'll be writing JavaScript code soon that will generate all of this HTML inside the sidebar. (Hint: Use CSS classes to style the header levels differently. Consider using the _name_ of the HTML header tag in the class name.)

--- a/src_js/components/sidebar/ResizeHandle.tsx
+++ b/src_js/components/sidebar/ResizeHandle.tsx
@@ -2,7 +2,7 @@
  * This component was largely inspired by: https://codepen.io/mcolo/pen/OJMjWda
  */
 import { h } from 'preact';
-import { useEffect, useRef, Ref } from 'preact/hooks';
+import { useEffect, useState, useRef, Ref } from 'preact/hooks';
 
 type PropsType = {
   sidebarRef: Ref<HTMLElement>;
@@ -21,6 +21,10 @@ const MAX_WIDTH = 650;
 export function ResizeHandle({ sidebarRef }: PropsType): h.JSX.Element {
   const resize_handle_ref = useRef<HTMLDivElement>(null);
   const resize_data_ref = useRef<ResizeDataType>(getInitialResizeData());
+
+  const [mainContentMarginLeft, setMainContentMarginLeft] = useState<
+    number | null
+  >(null);
 
   useEffect(() => {
     const onMouseMove = (e: MouseEvent) => {
@@ -64,6 +68,10 @@ export function ResizeHandle({ sidebarRef }: PropsType): h.JSX.Element {
     };
 
     const onMouseUp = () => {
+      const mainContentMargin = getMainContentMarginPx();
+      if (mainContentMargin != null) {
+        setMainContentMarginLeft(mainContentMargin);
+      }
       resize_data_ref.current = getInitialResizeData();
     };
 
@@ -73,7 +81,7 @@ export function ResizeHandle({ sidebarRef }: PropsType): h.JSX.Element {
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
     };
-  }, [resize_handle_ref, sidebarRef]);
+  }, [resize_handle_ref, sidebarRef, setMainContentMarginLeft]);
 
   return (
     <div
@@ -92,7 +100,15 @@ export function ResizeHandle({ sidebarRef }: PropsType): h.JSX.Element {
           startMainContentMargin: getMainContentMarginPx(),
         };
       }}
-    />
+    >
+      {mainContentMarginLeft ? (
+        <style>
+          {'.primer-spec-content-margin-extra {'}
+          {`  margin-left: ${mainContentMarginLeft}px`}
+          {'}'}
+        </style>
+      ) : null}
+    </div>
   );
 }
 

--- a/src_js/components/sidebar/ResizeHandle.tsx
+++ b/src_js/components/sidebar/ResizeHandle.tsx
@@ -60,10 +60,9 @@ export function ResizeHandle({ sidebarRef }: PropsType): h.JSX.Element {
           resize_handle_ref.current.style.left = `${newSidebarWidth}px`;
           // (3.3) Update the margin of the main content so that it doesn't
           //       hide underneath the Sidebar
-          const mainContentEl = getMainContentNode();
-          if (mainContentEl) {
-            mainContentEl.style.marginLeft = `${newMainContentMargin}px`;
-          }
+          getMainContentEls().forEach((el) => {
+            el.style.marginLeft = `${newMainContentMargin}px`;
+          });
         }
       }
     },
@@ -168,16 +167,22 @@ function getCurrentSidebarWidth(sidebarRef: Ref<HTMLElement>) {
 /**
  * Assumes that the screen is not small.
  */
-function getMainContentNode() {
-  return document.querySelector(
+function getMainContentEls() {
+  const els = document.querySelectorAll(
     '.primer-spec-content-margin-extra',
-  ) as HTMLElement | null;
+  ) as NodeListOf<HTMLElement>;
+  if (els.length <= 0) {
+    throw new Error(
+      'Primer Spec: While resizing sidebar, expected at least one main content node.',
+    );
+  }
+  return els;
 }
 
 function getMainContentMarginPx() {
-  const mainContentNode = getMainContentNode();
-  const startMainContentMarginRaw = mainContentNode
-    ? window.getComputedStyle(mainContentNode).getPropertyValue('margin-left')
+  const mainContentEls = getMainContentEls();
+  const startMainContentMarginRaw = mainContentEls
+    ? window.getComputedStyle(mainContentEls[0]).getPropertyValue('margin-left')
     : null;
   return startMainContentMarginRaw?.match(/^\d+px$/)
     ? parseInt(startMainContentMarginRaw, 10)

--- a/src_js/components/sidebar/ResizeHandle.tsx
+++ b/src_js/components/sidebar/ResizeHandle.tsx
@@ -1,0 +1,125 @@
+/**
+ * This component was largely inspired by: https://codepen.io/mcolo/pen/OJMjWda
+ */
+import { h } from 'preact';
+import { useEffect, useRef, Ref } from 'preact/hooks';
+
+type PropsType = {
+  sidebarRef: Ref<HTMLElement>;
+};
+
+type ResizeDataType = {
+  tracking: boolean;
+  startCursorScreenX: number | null;
+  startSidebarWidth: number | null;
+  startMainContentMargin: number | null;
+};
+
+const MIN_WIDTH = 250;
+const MAX_WIDTH = 650;
+
+export function ResizeHandle({ sidebarRef }: PropsType): h.JSX.Element {
+  const resize_handle_ref = useRef<HTMLDivElement>(null);
+  const resize_data_ref = useRef<ResizeDataType>(getInitialResizeData());
+
+  useEffect(() => {
+    const onMouseMove = (e: MouseEvent) => {
+      const {
+        startCursorScreenX,
+        startSidebarWidth,
+        startMainContentMargin,
+      } = resize_data_ref.current;
+
+      if (
+        startCursorScreenX != null &&
+        startSidebarWidth != null &&
+        startMainContentMargin != null
+      ) {
+        // (1) Calculate the new sidebar width
+        const cursorScreenXDelta = e.screenX - startCursorScreenX;
+        let newSidebarWidth = Math.max(
+          MIN_WIDTH,
+          startSidebarWidth + cursorScreenXDelta,
+        );
+        newSidebarWidth = Math.min(newSidebarWidth, MAX_WIDTH);
+
+        // (2) Use the width change to calculate the main content margin change
+        const widthDelta = newSidebarWidth - startSidebarWidth;
+        const newMainContentMargin = startMainContentMargin + widthDelta;
+
+        if (sidebarRef.current && resize_handle_ref.current) {
+          // (3.1) Update the Sidebar width
+          sidebarRef.current.style.width = `${newSidebarWidth}px`;
+          // (3.2) Update the position of the resize handle (so that it's next
+          //       to the Sidebar)
+          resize_handle_ref.current.style.left = `${newSidebarWidth}px`;
+          // (3.3) Update the margin of the main content so that it doesn't
+          //       hide underneath the Sidebar
+          const mainContentEl = getMainContentNode();
+          if (mainContentEl) {
+            mainContentEl.style.marginLeft = `${newMainContentMargin}px`;
+          }
+        }
+      }
+    };
+
+    const onMouseUp = () => {
+      resize_data_ref.current = getInitialResizeData();
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+  }, [resize_handle_ref, sidebarRef]);
+
+  return (
+    <div
+      ref={resize_handle_ref}
+      class="primer-spec-sidebar-resize-handle position-fixed top-0"
+      tabIndex={-1}
+      aria-hidden="true"
+      onMouseDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        resize_data_ref.current = {
+          tracking: true,
+          startCursorScreenX: e.screenX,
+          startSidebarWidth: sidebarRef.current?.offsetWidth ?? null,
+          startMainContentMargin: getMainContentMarginPx(),
+        };
+      }}
+    />
+  );
+}
+
+function getInitialResizeData(): ResizeDataType {
+  return {
+    tracking: false,
+    startCursorScreenX: null,
+    startSidebarWidth: null,
+    startMainContentMargin: null,
+  };
+}
+
+/**
+ * Assumes that the screen is not small.
+ */
+function getMainContentNode() {
+  return document.querySelector(
+    '.primer-spec-content-margin-extra',
+  ) as HTMLElement | null;
+}
+
+function getMainContentMarginPx() {
+  const mainContentNode = getMainContentNode();
+  const startMainContentMarginRaw = mainContentNode
+    ? window.getComputedStyle(mainContentNode).getPropertyValue('margin-left')
+    : null;
+  return startMainContentMarginRaw?.match(/^\d+px$/)
+    ? parseInt(startMainContentMarginRaw, 10)
+    : null;
+}

--- a/src_js/components/sidebar/index.tsx
+++ b/src_js/components/sidebar/index.tsx
@@ -14,6 +14,7 @@ import { usePrintInProgress } from '../../utils/hooks/print';
 import Storage from '../../utils/Storage';
 import SidebarContent from './SidebarContent';
 import getSitemapUrls from './getSitemapUrls';
+import { ResizeHandle } from './ResizeHandle';
 
 type SidebarProps = {
   contentNodeSelector: string;
@@ -101,43 +102,46 @@ export default function Sidebar(props: SidebarProps): h.JSX.Element {
   // We also need to unset the Sidebar's `tabIndex` to make its border
   // unfocusable.
   return (
-    <aside
-      ref={sidebar_ref}
-      class="primer-spec-sidebar position-fixed top-0 py-5 no-print"
-      aria-label="Contents Sidebar"
-      tabIndex={-1}
-    >
-      <h2 class="primer-spec-toc-ignore" id="primer-spec-toc-contents">
-        {sitemapUrls == null ? undefined : (
-          <Fragment>
-            <InlineNavButton
-              icon={IconType.HOME}
-              href={sitemapUrls.rootPage.url}
-              ariaLabel={sitemapUrls.rootPage.title || 'Home'}
-            />{' '}
-          </Fragment>
-        )}
-        Contents
-        <InlineButton
-          icon={IconType.SIDEBAR}
-          floatRight
-          onClick={saveScrollPositionThenToggleSidebar}
-          ariaLabel="Close navigation pane"
-        />
-      </h2>
-      <br />
-      <SidebarContent sitemap={sitemapUrls}>
-        <TableOfContents
-          contentNodeSelector={props.contentNodeSelector}
-          isSmallScreen={props.isSmallScreen}
-          sidebarShown={props.sidebarShown}
-          settingsShown={props.settingsShown}
-          activeSectionOffsetY={props.activeSectionOffsetY}
-          onToggleSidebar={saveScrollPositionThenToggleSidebar}
-          onToggleSettings={props.onToggleSettings}
-        />
-      </SidebarContent>
-    </aside>
+    <Fragment>
+      <aside
+        ref={sidebar_ref}
+        class="primer-spec-sidebar position-fixed top-0 py-5 no-print"
+        aria-label="Contents Sidebar"
+        tabIndex={-1}
+      >
+        <h2 class="primer-spec-toc-ignore" id="primer-spec-toc-contents">
+          {sitemapUrls == null ? undefined : (
+            <Fragment>
+              <InlineNavButton
+                icon={IconType.HOME}
+                href={sitemapUrls.rootPage.url}
+                ariaLabel={sitemapUrls.rootPage.title || 'Home'}
+              />{' '}
+            </Fragment>
+          )}
+          Contents
+          <InlineButton
+            icon={IconType.SIDEBAR}
+            floatRight
+            onClick={saveScrollPositionThenToggleSidebar}
+            ariaLabel="Close navigation pane"
+          />
+        </h2>
+        <br />
+        <SidebarContent sitemap={sitemapUrls}>
+          <TableOfContents
+            contentNodeSelector={props.contentNodeSelector}
+            isSmallScreen={props.isSmallScreen}
+            sidebarShown={props.sidebarShown}
+            settingsShown={props.settingsShown}
+            activeSectionOffsetY={props.activeSectionOffsetY}
+            onToggleSidebar={saveScrollPositionThenToggleSidebar}
+            onToggleSettings={props.onToggleSettings}
+          />
+        </SidebarContent>
+      </aside>
+      {isSmallScreen ? null : <ResizeHandle sidebarRef={sidebar_ref} />}
+    </Fragment>
   );
 }
 

--- a/src_js/subthemes/Subtheme.ts
+++ b/src_js/subthemes/Subtheme.ts
@@ -26,6 +26,8 @@ export const SUBTHEME_VARS = [
   '--sidebar-tt-active-border',
   '--sidebar-tt-active-border-radius',
 
+  '--sidebar-resize-handle',
+
   '--main-heading-text-color',
   '--main-heading-link-color',
   '--main-link-color',

--- a/src_js/subthemes/definitions/bella.theme.ts
+++ b/src_js/subthemes/definitions/bella.theme.ts
@@ -25,6 +25,8 @@ const bella_theme_vars: SubthemeDefinitionType = {
     '--sidebar-active-toc-h2-section-link-color': 'white',
     '--sidebar-toc-section-link-color': 'rgb(58, 58, 58)',
 
+    '--sidebar-resize-handle': '#ccc',
+
     '--main-heading-text-color': BELLA_PRIMARY_TEXT_COLOR,
     '--main-heading-link-color': BELLA_MAIN_LINK_COLOR,
     '--main-link-color': BELLA_MAIN_LINK_COLOR,
@@ -48,6 +50,8 @@ const bella_theme_vars: SubthemeDefinitionType = {
     '--sidebar-active-toc-h2-section-link-color': BELLA_DARK_SIDEBAR_HEADING_COLOR,
     '--sidebar-toc-section-link-color': BELLA_DARK_SIDEBAR_HEADING_COLOR,
     '--sidebar-tt-active-text-color': BELLA_DARK_SIDEBAR_HEADING_COLOR,
+
+    '--sidebar-resize-handle': '#555',
 
     '--main-heading-text-color': BELLA_DARK_PRIMARY_HEADING_COLOR,
     '--main-heading-link-color': BELLA_DARK_MAIN_LINK_COLOR,

--- a/src_js/subthemes/definitions/default.theme.ts
+++ b/src_js/subthemes/definitions/default.theme.ts
@@ -24,6 +24,8 @@ const default_theme_vars: SubthemeDefinitionType = {
     '--sidebar-toc-section-link-color': DEFAULT_DARK_SIDEBAR_HEADING_COLOR,
     '--sidebar-tt-active-text-color': DEFAULT_DARK_BG_COLOR,
 
+    '--sidebar-resize-handle': '#333',
+
     '--main-heading-text-color': DEFAULT_DARK_MAIN_HEADING_COLOR,
     '--main-heading-link-color': DEFAULT_DARK_LINK_COLOR,
     '--main-link-color': DEFAULT_DARK_LINK_COLOR,

--- a/src_js/subthemes/definitions/modern.theme.ts
+++ b/src_js/subthemes/definitions/modern.theme.ts
@@ -20,6 +20,8 @@ const modern_theme_vars: SubthemeDefinitionType = {
     '--sidebar-toc-h1-border-color': MODERN_SPECIAL_COLOR,
     '--sidebar-toc-h2-link-color': 'white',
 
+    '--sidebar-resize-handle': '#246161',
+
     '--sidebar-active-toc-section-bg-color': 'rgb(248, 255, 248)',
     '--sidebar-active-toc-section-link-color': MODERN_PRIMARY_COLOR,
     '--sidebar-active-toc-h1-section-link-color': MODERN_PRIMARY_COLOR,
@@ -49,6 +51,8 @@ const modern_theme_vars: SubthemeDefinitionType = {
     '--sidebar-active-toc-h2-section-link-color': MODERN_DARK_SIDEBAR_BG_COLOR,
     '--sidebar-toc-section-link-color': 'white',
     '--sidebar-tt-active-text-color': MODERN_DARK_SIDEBAR_BG_COLOR,
+
+    '--sidebar-resize-handle': '#246161',
 
     '--main-heading-text-color': MODERN_DARK_HEADING_COLOR,
     '--main-heading-link-color': MODERN_DARK_HEADING_COLOR,

--- a/src_js/subthemes/definitions/xcode_civic.theme.ts
+++ b/src_js/subthemes/definitions/xcode_civic.theme.ts
@@ -26,6 +26,8 @@ const xcode_dark_theme_vars: SubthemeDefinitionType = {
     '--sidebar-active-toc-h2-section-link-color': 'white',
     '--sidebar-toc-section-link-color': XCODE_DARK_SIDEBAR_HEADING_COLOR,
 
+    '--sidebar-resize-handle': XCODE_DARK_MAIN_LINK_COLOR,
+
     '--main-heading-text-color': XCODE_DARK_MAIN_HEADING_COLOR,
     '--main-heading-link-color': XCODE_DARK_MAIN_HEADING_COLOR,
     '--main-link-color': XCODE_DARK_MAIN_LINK_COLOR,
@@ -66,6 +68,8 @@ const xcode_dark_theme_vars: SubthemeDefinitionType = {
     '--sidebar-active-toc-h1-section-link-color': 'white',
     '--sidebar-active-toc-h2-section-link-color': 'white',
     '--sidebar-toc-section-link-color': 'white',
+
+    '--sidebar-resize-handle': XCODE_DARK_MAIN_HEADING_COLOR,
 
     '--main-heading-text-color': XCODE_DARK_MAIN_HEADING_COLOR,
     '--main-heading-link-color': XCODE_DARK_MAIN_HEADING_COLOR,

--- a/src_js/utils/Storage.ts
+++ b/src_js/utils/Storage.ts
@@ -52,8 +52,8 @@ export default {
    *
    * Retrieve items set using this method using `Storage.getForPage()`.
    */
-  setForPage(key: string, value: string): void {
-    return this.set(mangleKeyWithPagePath(key), value);
+  setForPage(key: string, value: string | number): void {
+    return this.set(mangleKeyWithPagePath(key), value.toString());
   },
 
   /**


### PR DESCRIPTION
## Context

Closes #34. I've been meaning to implement this since the very first iteration of Primer Spec, but never got around to it 😅 

This PR makes the Sidebar resizable (with minimum and maximum width constraints). The drag-handle highlights subtly when you hover between the Sidebar and the main content.

## Validation
Visit PREVIEW#207 and play around with the resizable Sidebar!
- Notice how the Sidebar has minimum and maximum widths.
- Try refreshing the page. The Sidebar will render with the resized-width.

On small screens (for instance, on mobile phones), the sidebar should not be resizable.



https://user-images.githubusercontent.com/12139762/188757324-459cb159-2f42-499d-82ea-11c4e487b3ef.mov

