### PR TITLE
[Cleanup] Simply custom print hooks

### DIFF
--- a/src_js/components/PrimerSpec.tsx
+++ b/src_js/components/PrimerSpec.tsx
@@ -63,18 +63,16 @@ export default function PrimerSpec(props: PropsType): h.JSX.Element {
   };
 
   // Listen for print events
-  const beforePrint = useCallback(useBeforePrint, []);
-  const afterPrint = useCallback(useAfterPrint, []);
-  useEffect(() => {
-    return beforePrint(() => {
+  useBeforePrint(
+    useCallback(() => {
       toggleItalicsInChrome(false);
-    });
-  }, [beforePrint]);
-  useEffect(() => {
-    return afterPrint(() => {
+    }, []),
+  );
+  useAfterPrint(
+    useCallback(() => {
       toggleItalicsInChrome(true);
-    });
-  }, [afterPrint]);
+    }, []),
+  );
 
   // Expose Debug methods
   useEffect(() => {

--- a/src_js/components/settings/index.tsx
+++ b/src_js/components/settings/index.tsx
@@ -1,5 +1,4 @@
 import { h } from 'preact';
-import { useCallback, useEffect } from 'preact/hooks';
 import clsx from 'clsx';
 import Config from '../../Config';
 import { Subthemes, updateTheme, normalizeSubthemeMode } from '../../subthemes';
@@ -37,21 +36,13 @@ export default function Settings(props: PropsType): h.JSX.Element | null {
   usePrefersDarkMode();
 
   // If a print is in progress, temporarily reset the theme to default light.
-  const beforePrint = useCallback(useBeforePrint, []);
-  const afterPrint = useCallback(useAfterPrint, []);
-  useEffect(() => {
-    return beforePrint(() =>
-      updateTheme({ name: 'default', mode: 'light' }, false),
-    );
-  }, [beforePrint]);
-  useEffect(() => {
-    return afterPrint(() =>
-      updateTheme(
-        { name: props.currentSubthemeName, mode: props.currentSubthemeMode },
-        false,
-      ),
-    );
-  }, [afterPrint, props.currentSubthemeName, props.currentSubthemeMode]);
+  useBeforePrint(() => updateTheme({ name: 'default', mode: 'light' }, false));
+  useAfterPrint(() =>
+    updateTheme(
+      { name: props.currentSubthemeName, mode: props.currentSubthemeMode },
+      false,
+    ),
+  );
 
   if (!props.settingsShown || is_print_in_progress) {
     return null;

--- a/src_js/utils/hooks/print.ts
+++ b/src_js/utils/hooks/print.ts
@@ -20,7 +20,7 @@ export function usePrintInProgress(): boolean {
  * useBeforePrint(
  *   useCallback(() => {
  *     // Your logic here
- *   }),
+ *   }, []),
  * );
  * ```
  * @param handler Imperative function to be invoked onbeforeprint
@@ -60,7 +60,7 @@ export function useBeforePrint(handler: () => void): void {
  * useBeforePrint(
  *   useCallback(() => {
  *     // Your logic here
- *   }),
+ *   }, []),
  * );
  * ```
  * @param handler Imperative function to execute onafterprint


### PR DESCRIPTION
When I first implemented the hooks for handling print events, I attempted to solve the ESLint warnings without fully understanding what I was doing.

Now that I better understand how `useCallback()` and `useEffect()` work, I was able to simplify the code a bit. We also now have fewer print-handlers registered on the page, and they update less-frequently :)