### PR TITLE
Use GitHub Actions to deploy GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+# GitHub Pages Configuration
+#
+# This workflow builds the repository's website and deploys it using GitHub Pages.
+name: Deploy website with GitHub Pages
+
+on:
+  # Run on all pushes to main.
+  push:
+    branches: ['main']
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+# We have two jobs:
+# (1) A "build" job that's responsible for building the website using Jekyll.
+# (2) A "deploy" job that pushes the output of the build job to GitHub Pages.
+jobs:
+  # (1) Build job
+  build:
+    runs-on: ubuntu-latest
+
+    # Sequence of tasks for this job
+    steps:
+      # Check out latest code using a pre-existing GH action
+      # Docs: https://github.com/actions/checkout
+      - name: 📁 Checkout code
+        uses: actions/checkout@v2
+
+      # Build the Primer Spec website. The action places the fully-built
+      # website in an `_site/` directory.
+      # Docs: https://github.com/seshrs/build-primer-spec-action
+      - name: 🛠 Build Primer Spec website
+        uses: seshrs/build-primer-spec-action@v1
+
+      # Upload the _site directory created in the above step for use by
+      # GitHub Pages.
+      # Docs: https://github.com/actions/upload-pages-artifact
+      - name: 🏺 Upload artifact
+        uses: actions/upload-pages-artifact@v1
+
+  # (2) Deploy job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Primer Spec is a Jekyll theme, which means you can start using this theme with [
      with_frontmatter: true
    ```
 
-4. Deploy your site with GitHub pages!
+4. [Deploy your site with GitHub pages.](https://github.com/seshrs/build-primer-spec-action#setting-up-github-pages-deployment)
 
 This repository hosts a Primer Spec site too! The original Markdown content is in [index.md](index.md), and you can preview the page at [https://eecs485staff.github.io/primer-spec/index.html](https://eecs485staff.github.io/primer-spec/).
 


### PR DESCRIPTION
## Context

Now that GitHub Pages supports [deployments via GitHub Actions,](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow), this commit:

- Updates the README to recommend deploying Primer Spec websites using GitHub Actions.
- Uses GitHub Actions to deploy this repository's website.

Using GitHub Actions gives us two benefits:
- We can add arbitrary steps to the GitHub Actions build step (https://github.com/seshrs/build-primer-spec-action). This means that we can theoretically add arbitrary Jekyll plugins, generate PDFs (#136) and more!
- [Minor] This repository can make `develop` the main Primer Spec branch for PRs.

**Note:** This PR is labeled as a "minor" change because these changes will not break course websites that use Classic GitHub Pages.

## Next Steps
Ideally, the Primer Spec Preview workflows should update to use the custom build-action step also, but that will require adding some config options to the action. For now, we'll just need to remember to keep the actions steps in sync.