### PR TITLE
[Code blocks] Magic Comments to mark highlight ranges

### DIFF
--- a/demo/enhanced-code-blocks.md
+++ b/demo/enhanced-code-blocks.md
@@ -81,6 +81,10 @@ So long lives this and this gives life to thee.
 
 ## Highlighted lines
 
+### Using `data-highlight` attribute
+
+Specify which line-number ranges of a code block need to be highlighted. For instance:
+
 <!-- prettier-ignore-start -->
 ```
 Shall I compare thee to a summer’s day?
@@ -137,6 +141,52 @@ So long lives this and this gives life to thee.
 
 </details>
 
+### Using "magic comments"
+
+<div class="primer-spec-callout warning" markdown="1">
+WARNING: "Magic comments" only work when syntax-highlighting is enabled! This means that you _must_ specify the code block's language first.
+</div>
+
+Surround the lines that you'd like to highlight with the magic comments `primer-spec-highlight-start` and `primer-spec-highlight-end` to indicate the highlighted lines. For instance, the following Markdown:
+
+<!-- prettier-ignore-start -->
+
+````
+```python
+x = {
+  # primer-spec-highlight-start
+  # This dict refers John, whose age is 30
+  "name": "John",
+  "age": 30,
+  # primer-spec-highlight-end
+  "cars": [
+    {"model": "BMW 230", "mpg": 27.5},
+    {"model": "Ford Edge", "mpg": 24.1}
+  ]
+}
+```
+````
+{: data-title="Markdown source for magic comments" data-highlight="3,7" }
+
+Results in the following code block:
+
+```python
+x = {
+  # primer-spec-highlight-start
+  # This dict refers John, whose age is 30
+  "name": "John",
+  "age": 30,
+  # primer-spec-highlight-end
+  "cars": [
+    {"model": "BMW 230", "mpg": 27.5},
+    {"model": "Ford Edge", "mpg": 24.1}
+  ]
+}
+```
+<!-- prettier-ignore-end -->
+
+You can use the comment syntax relevant for your code block's language. For instance, you can use `// ...` or `/* ... */` in JavaScript, or `<!-- ... -->` in HTML. However, the magic comment **_must_** be the only content on its entire line.
+
 ## Code example
 
 <!-- prettier-ignore-start -->
@@ -172,16 +222,16 @@ print(json.dumps(x, indent=4, separators=(". ", " = ")))
 import json
 
 x = {
-"name": "John",
-"age": 30,
-"married": True,
-"divorced": False,
-"children": ("Ann","Billy"),
-"pets": None,
-"cars": [
-{"model": "BMW 230", "mpg": 27.5},
-{"model": "Ford Edge", "mpg": 24.1}
-]
+  "name": "John",
+  "age": 30,
+  "married": True,
+  "divorced": False,
+  "children": ("Ann","Billy"),
+  "pets": None,
+  "cars": [
+    {"model": "BMW 230", "mpg": 27.5},
+    {"model": "Ford Edge", "mpg": 24.1}
+  ]
 }
 
 # use . and a space to separate objects, and a space, a = and a space to separate keys from their values:

--- a/demo/enhanced-code-blocks.md
+++ b/demo/enhanced-code-blocks.md
@@ -155,7 +155,7 @@ Surround the lines that you'd like to highlight with the magic comments `primer-
 ```python
 x = {
   # primer-spec-highlight-start
-  # This dict refers John, whose age is 30
+  # This dict refers to John, whose age is 30
   "name": "John",
   "age": 30,
   # primer-spec-highlight-end
@@ -173,7 +173,7 @@ Results in the following code block:
 ```python
 x = {
   # primer-spec-highlight-start
-  # This dict refers John, whose age is 30
+  # This dict refers to John, whose age is 30
   "name": "John",
   "age": 30,
   # primer-spec-highlight-end

--- a/docs/USAGE_ADVANCED.md
+++ b/docs/USAGE_ADVANCED.md
@@ -191,7 +191,7 @@ See the [Callouts demo](https://eecs485staff.github.io/primer-spec/demo/callouts
 
 Primer Spec automatically upgrades your code blocks! These enhanced code blocks let viewers copy code easily, while also letting you highlight important lines in the code.
 
-To highlight lines in a codeblock, specify them in a `data-highlight` attribute like this::
+To highlight lines in a codeblock, specify them in a [`data-highlight` attribute](https://eecs485staff.github.io/primer-spec/demo/enhanced-code-blocks.html#using-data-highlight-attribute), or surround them in ["magic comments"](https://eecs485staff.github.io/primer-spec/demo/enhanced-code-blocks.html#using-magic-comments). For instance:
 
 <!-- prettier-ignore-start -->
 ````markdown
@@ -200,12 +200,16 @@ import os
 print("Hello world")
 print("spam and eggs")
 print("Ni! Ni! Ni!")
+# Or surround them in "magic comments"
+# primer-spec-highlight-start
+print("This line gets highlighted too!")
+# primer-spec-highlight-end
 ```
 {: data-highlight="1,3" }
 ````
 <!-- prettier-ignore-end -->
 
-If you'd like to revert back to the original "legacy" style of code blocks, simply add the attribute `data-variant="legacy"`:
+If you'd like to revert back to the original "legacy" style of code blocks, simply add the attribute [`data-variant="legacy"`](https://eecs485staff.github.io/primer-spec/demo/enhanced-code-blocks.html#using-variants):
 
 <!-- prettier-ignore-start -->
 ````markdown

--- a/src_js/components/main_content/enhanced_code_blocks/__tests__/parseCodeHighlightRanges.test.ts
+++ b/src_js/components/main_content/enhanced_code_blocks/__tests__/parseCodeHighlightRanges.test.ts
@@ -59,7 +59,7 @@ describe('parseCodeHighlightRanges', () => {
     });
 
     test('multiple ranges and lines', () => {
-      expect(parseCodeHighlightRanges('4, 24-27, 3-5', 30)).toEqual(
+      expect(parseCodeHighlightRanges(', 4, 24-27, 3-5', 30)).toEqual(
         new Set([3, 4, 5, 24, 25, 26, 27]),
       );
     });
@@ -84,14 +84,20 @@ describe('parseCodeHighlightRanges', () => {
       );
     });
 
-    test('single line number out of bounds after removing lines', () => {
-      expect(parseCodeHighlightRanges('30', 30, [20])).toEqual(new Set());
+    test('single line number almost out of bounds after removing lines', () => {
+      expect(parseCodeHighlightRanges('30', 30, [20])).toEqual(new Set([29]));
     });
 
     test('multiple line numbers with multiple removed lines', () => {
       expect(
         parseCodeHighlightRanges('20-24,6,12-14', 30, [22, 8, 12]),
       ).toEqual(new Set([6, 11, 12, 18, 19, 20, 21]));
+    });
+
+    test('range contains last line, but some lines removed', () => {
+      expect(parseCodeHighlightRanges('22-24', 24, [8, 9])).toEqual(
+        new Set([20, 21, 22]),
+      );
     });
 
     test('invalid removed lines', () => {

--- a/src_js/components/main_content/enhanced_code_blocks/__tests__/parseCodeHighlightRanges.test.ts
+++ b/src_js/components/main_content/enhanced_code_blocks/__tests__/parseCodeHighlightRanges.test.ts
@@ -1,65 +1,103 @@
 import { parseCodeHighlightRanges } from '../parseCodeHighlightRanges';
 
 describe('parseCodeHighlightRanges', () => {
-  test('empty string', () => {
-    expect(parseCodeHighlightRanges('', 30)).toEqual(new Set());
+  describe('basic tests', () => {
+    test('empty string', () => {
+      expect(parseCodeHighlightRanges('', 30)).toEqual(new Set());
+    });
+
+    test('invalid string', () => {
+      expect(parseCodeHighlightRanges('spam and eggs', 30)).toEqual(new Set());
+    });
+
+    test('invalid comma-separated string', () => {
+      expect(parseCodeHighlightRanges('spam,eggs', 30)).toEqual(new Set());
+    });
+
+    test('single line number', () => {
+      expect(parseCodeHighlightRanges('24', 30)).toEqual(new Set([24]));
+    });
+
+    test('single line number out of bounds', () => {
+      expect(parseCodeHighlightRanges('32', 30)).toEqual(new Set());
+    });
+
+    test('single line number at upper bound', () => {
+      expect(parseCodeHighlightRanges('30', 30)).toEqual(new Set([30]));
+    });
+
+    test('single line number at lower bound', () => {
+      expect(parseCodeHighlightRanges('1', 30)).toEqual(new Set([1]));
+    });
+
+    test('single range', () => {
+      expect(parseCodeHighlightRanges('18-21', 30)).toEqual(
+        new Set([18, 19, 20, 21]),
+      );
+    });
+
+    test('single range completely out of bounds', () => {
+      expect(parseCodeHighlightRanges('32-38', 30)).toEqual(new Set());
+    });
+
+    test('single range partially out of bounds', () => {
+      expect(parseCodeHighlightRanges('28-32', 30)).toEqual(new Set());
+    });
+
+    test('single range with inverted bounds', () => {
+      expect(parseCodeHighlightRanges('28-26', 30)).toEqual(new Set());
+    });
+
+    test('multiple single numbers', () => {
+      expect(parseCodeHighlightRanges('4,0,6', 30)).toEqual(new Set([4, 6]));
+    });
+
+    test('multiple ranges', () => {
+      expect(parseCodeHighlightRanges('14-15,24-32,12-14', 30)).toEqual(
+        new Set([12, 13, 14, 15]),
+      );
+    });
+
+    test('multiple ranges and lines', () => {
+      expect(parseCodeHighlightRanges('4, 24-27, 3-5', 30)).toEqual(
+        new Set([3, 4, 5, 24, 25, 26, 27]),
+      );
+    });
   });
 
-  test('invalid string', () => {
-    expect(parseCodeHighlightRanges('spam and eggs', 30)).toEqual(new Set());
-  });
+  describe('with removed lines', () => {
+    test('single line number before removed line number', () => {
+      expect(parseCodeHighlightRanges('24', 30, [26])).toEqual(new Set([24]));
+    });
 
-  test('invalid comma-separated string', () => {
-    expect(parseCodeHighlightRanges('spam,eggs', 30)).toEqual(new Set());
-  });
+    test('single line number is a removed line number', () => {
+      expect(parseCodeHighlightRanges('24', 30, [24])).toEqual(new Set());
+    });
 
-  test('single line number', () => {
-    expect(parseCodeHighlightRanges('24', 30)).toEqual(new Set([24]));
-  });
+    test('single line number after removed line number', () => {
+      expect(parseCodeHighlightRanges('24', 30, [20])).toEqual(new Set([23]));
+    });
 
-  test('single line number out of bounds', () => {
-    expect(parseCodeHighlightRanges('32', 30)).toEqual(new Set());
-  });
+    test('single line number after two removed lines', () => {
+      expect(parseCodeHighlightRanges('24', 30, [20, 12])).toEqual(
+        new Set([22]),
+      );
+    });
 
-  test('single line number at upper bound', () => {
-    expect(parseCodeHighlightRanges('30', 30)).toEqual(new Set([30]));
-  });
+    test('single line number out of bounds after removing lines', () => {
+      expect(parseCodeHighlightRanges('30', 30, [20])).toEqual(new Set());
+    });
 
-  test('single line number at lower bound', () => {
-    expect(parseCodeHighlightRanges('1', 30)).toEqual(new Set([1]));
-  });
+    test('multiple line numbers with multiple removed lines', () => {
+      expect(
+        parseCodeHighlightRanges('20-24,6,12-14', 30, [22, 8, 12]),
+      ).toEqual(new Set([6, 11, 12, 18, 19, 20, 21]));
+    });
 
-  test('single range', () => {
-    expect(parseCodeHighlightRanges('18-21', 30)).toEqual(
-      new Set([18, 19, 20, 21]),
-    );
-  });
-
-  test('single range completely out of bounds', () => {
-    expect(parseCodeHighlightRanges('32-38', 30)).toEqual(new Set());
-  });
-
-  test('single range partially out of bounds', () => {
-    expect(parseCodeHighlightRanges('28-32', 30)).toEqual(new Set());
-  });
-
-  test('single range with inverted bounds', () => {
-    expect(parseCodeHighlightRanges('28-26', 30)).toEqual(new Set());
-  });
-
-  test('multiple single numbers', () => {
-    expect(parseCodeHighlightRanges('4,0,6', 30)).toEqual(new Set([4, 6]));
-  });
-
-  test('multiple ranges', () => {
-    expect(parseCodeHighlightRanges('14-15,24-32,12-14', 30)).toEqual(
-      new Set([12, 13, 14, 15]),
-    );
-  });
-
-  test('multiple ranges and lines', () => {
-    expect(parseCodeHighlightRanges('4, 24-27, 3-5', 30)).toEqual(
-      new Set([3, 4, 5, 24, 25, 26, 27]),
-    );
+    test('invalid removed lines', () => {
+      expect(parseCodeHighlightRanges('20-24', 30, [32, 8, 12])).toEqual(
+        new Set([18, 19, 20, 21, 22]),
+      );
+    });
   });
 });

--- a/src_js/components/main_content/enhanced_code_blocks/createEnhancedCodeBlock.tsx
+++ b/src_js/components/main_content/enhanced_code_blocks/createEnhancedCodeBlock.tsx
@@ -54,7 +54,7 @@ export function createEnhancedCodeBlock(options: {
   } = parseMagicComments(lines);
 
   const highlightRanges = parseCodeHighlightRanges(
-    `${rawHighlightRanges},${additionalHighlightRanges}`,
+    [rawHighlightRanges, additionalHighlightRanges].filter(Boolean).join(','),
     lines.length,
     removedLineNumbers,
   );

--- a/src_js/components/main_content/enhanced_code_blocks/parseCodeHighlightRanges.ts
+++ b/src_js/components/main_content/enhanced_code_blocks/parseCodeHighlightRanges.ts
@@ -7,12 +7,24 @@
  * `Set([13, 24, 25, 26, 27])`
  *
  * @param rawHighlightRanges A comma-separated string representing ranges
- * @param maxLineNumber The maximum valid line number
+ * @param maxLineNumber The maximum valid line number (BEFORE removing lines)
+ * @param removedLineNumbers A list of line numbers that were removed from the
+ *                           final code block (hence the raw highlight ranges
+ *                           need to be updated based on the removed line
+ *                           numbers)
  */
 export function parseCodeHighlightRanges(
   rawHighlightRanges: string | null,
   maxLineNumber: number,
+  removedLineNumbers?: Array<number>,
 ): Set<number> {
+  const validRemovedLines = (
+    removedLineNumbers ?? []
+  ).filter((removedLineNumber) =>
+    isNumWithinInclusiveRange(removedLineNumber, 1, maxLineNumber),
+  );
+  const normalizedMaxLineNumber = maxLineNumber - validRemovedLines.length;
+
   const highlightedLines = new Set<number>();
   if (!rawHighlightRanges) {
     return highlightedLines;
@@ -22,20 +34,30 @@ export function parseCodeHighlightRanges(
   ranges.forEach((range) => {
     // First check if it's a single number
     const potentialLineNum = +range;
-    if (isNumWithinInclusiveRange(potentialLineNum, 1, maxLineNumber)) {
-      highlightedLines.add(potentialLineNum);
+    if (
+      isNumWithinInclusiveRange(potentialLineNum, 1, normalizedMaxLineNumber)
+    ) {
+      addLineNumberToHighlightRanges(
+        potentialLineNum,
+        highlightedLines,
+        validRemovedLines,
+      );
     } else {
       const rangeParts = range.trim().split('-');
       if (rangeParts.length === 2) {
         const lower = +rangeParts[0];
         const upper = +rangeParts[1];
         if (
-          isNumWithinInclusiveRange(lower, 1, maxLineNumber) &&
-          isNumWithinInclusiveRange(upper, 1, maxLineNumber) &&
+          isNumWithinInclusiveRange(lower, 1, normalizedMaxLineNumber) &&
+          isNumWithinInclusiveRange(upper, 1, normalizedMaxLineNumber) &&
           lower <= upper
         ) {
           for (let i = lower; i <= upper; ++i) {
-            highlightedLines.add(i);
+            addLineNumberToHighlightRanges(
+              i,
+              highlightedLines,
+              validRemovedLines,
+            );
           }
         }
       }
@@ -54,4 +76,34 @@ function isNumWithinInclusiveRange(
   upper: number,
 ): boolean {
   return num != null && !Number.isNaN(num) && num >= lower && num <= upper;
+}
+
+function addLineNumberToHighlightRanges(
+  lineNumberToAdd: number,
+  highlightedLineRanges: Set<number>,
+  removedLineNumbers?: Array<number> | null,
+): void {
+  const normalizedNum = normalizeAfterRemovingLines(
+    lineNumberToAdd,
+    removedLineNumbers,
+  );
+  if (normalizedNum != null) {
+    highlightedLineRanges.add(normalizedNum);
+  }
+}
+
+function normalizeAfterRemovingLines(
+  num: number,
+  removedLineNumbers?: Array<number> | null,
+): number | null {
+  if (removedLineNumbers == null) {
+    return num;
+  } else if (removedLineNumbers.includes(num)) {
+    return null;
+  }
+  return (
+    num -
+    removedLineNumbers.filter((removedLineNumber) => num >= removedLineNumber)
+      .length
+  );
 }

--- a/src_js/components/main_content/enhanced_code_blocks/parseCodeHighlightRanges.ts
+++ b/src_js/components/main_content/enhanced_code_blocks/parseCodeHighlightRanges.ts
@@ -32,14 +32,16 @@ export function parseCodeHighlightRanges(
 
   const ranges = rawHighlightRanges.split(',');
   ranges.forEach((range) => {
+    if (range === '') {
+      return;
+    }
     // First check if it's a single number
     const potentialLineNum = +range;
-    if (
-      isNumWithinInclusiveRange(potentialLineNum, 1, normalizedMaxLineNumber)
-    ) {
+    if (isNumWithinInclusiveRange(potentialLineNum, 1, maxLineNumber)) {
       addLineNumberToHighlightRanges(
         potentialLineNum,
         highlightedLines,
+        normalizedMaxLineNumber,
         validRemovedLines,
       );
     } else {
@@ -48,14 +50,15 @@ export function parseCodeHighlightRanges(
         const lower = +rangeParts[0];
         const upper = +rangeParts[1];
         if (
-          isNumWithinInclusiveRange(lower, 1, normalizedMaxLineNumber) &&
-          isNumWithinInclusiveRange(upper, 1, normalizedMaxLineNumber) &&
+          isNumWithinInclusiveRange(lower, 1, maxLineNumber) &&
+          isNumWithinInclusiveRange(upper, 1, maxLineNumber) &&
           lower <= upper
         ) {
           for (let i = lower; i <= upper; ++i) {
             addLineNumberToHighlightRanges(
               i,
               highlightedLines,
+              normalizedMaxLineNumber,
               validRemovedLines,
             );
           }
@@ -81,13 +84,14 @@ function isNumWithinInclusiveRange(
 function addLineNumberToHighlightRanges(
   lineNumberToAdd: number,
   highlightedLineRanges: Set<number>,
+  normalizedMaxLineNumber: number,
   removedLineNumbers?: Array<number> | null,
 ): void {
   const normalizedNum = normalizeAfterRemovingLines(
     lineNumberToAdd,
     removedLineNumbers,
   );
-  if (normalizedNum != null) {
+  if (normalizedNum != null && normalizedNum <= normalizedMaxLineNumber) {
     highlightedLineRanges.add(normalizedNum);
   }
 }


### PR DESCRIPTION
## Context

While researching other static site generators in #213, I discovered a really cool syntax for highlighting code block lines in [Docusaurus](https://docusaurus.io/docs/markdown-features/code-blocks#highlighting-with-comments).

This PR adds the ability to highlight code block lines using "magic comments". Primer Spec will recognize code block lines with comments `primer-spec-highlight-start` and `primer-spec-highlight-end`, and will automatically ensure that the lines in between are highlighted!

This only works with code blocks with syntax-highlighting, and only for pages built using Jekyll.

## Validation

Check out the demo preview URL: https://preview.sesh.rs/previews/eecs485staff/primer-spec/218/demo/enhanced-code-blocks.html#markdown-source-for-magic-comments-6

It contains the following code block:
````
```python
x = {
  # primer-spec-highlight-start
  # This dict refers John, whose age is 30
  "name": "John",
  "age": 30,
  # primer-spec-highlight-end
  "cars": [
    {"model": "BMW 230", "mpg": 27.5},
    {"model": "Ford Edge", "mpg": 24.1}
  ]
}
```
````

Which renders without the magic comments, and with the correct lines highlighted:
> <img width="1017" alt="image" src="https://user-images.githubusercontent.com/12139762/196071672-13d21719-4b79-46dd-8126-00e259ed58a8.png#gh-light-mode-only">
> <img width="1015" alt="image" src="https://user-images.githubusercontent.com/12139762/196071635-67fa956e-f27d-4cbb-a3ab-36bd4c5d0773.png#gh-dark-mode-only">


I also locally tested the following scenarios:
- HTML and JS code blocks (with different comment syntax)
- Code blocks with both magic comments *and* a `data-highlight` attribute