### PR TITLE
[Enhanced code blocks] Copy button should not omit lines with no text by default

### DIFF
--- a/src_js/components/main_content/enhanced_code_blocks/genCopyButton.tsx
+++ b/src_js/components/main_content/enhanced_code_blocks/genCopyButton.tsx
@@ -86,7 +86,9 @@ const CONSOLE_COPY_LINES_MAP_FN = (line: HTMLElement) => {
  * map/filter method to extract text from each line.
  *
  * @param codeblock The codeblock whose lines need to be copied
- * @param mapFn (OPTIONAL) A method that extracts text from a given line HTMLElement
+ * @param mapFn (OPTIONAL) A method that extracts text from a given line
+ *              HTMLElement. If the method returns `null`, the line is
+ *              *omitted* (and a newline will not be copied).
  */
 async function copyLines(
   codeblock: HTMLElement,
@@ -97,7 +99,9 @@ async function copyLines(
   const lines = codeblock.querySelectorAll(
     `.${CODEBLOCK_LINE_CLASS}`,
   ) as NodeListOf<HTMLElement>;
-  const linesOfText = [...lines].map((line) => mapFn(line)).filter(Boolean);
+  const linesOfText = [...lines]
+    .map((line) => mapFn(line))
+    .filter((lineText) => lineText != null);
   const text = linesOfText.join('\n');
   await navigator.clipboard.writeText(text);
 }


### PR DESCRIPTION
Fixes #221.

The bug is kind-of embarrassing. When you click the "copy" button, we run a "mapping" function on each line that determines what text should be copied.
I forgot that if a line was empty, the mapping function would retun an empty string, which is "falsy" according to the `Boolean` test. I really should have explicitly checked that the map function's return value is not nullish before excluding it from the copied text. 😅 