### PR TITLE
[PDF] Automatic PDF Generation

### DIFF
--- a/.github/workflows/upload-develop-preview.yml
+++ b/.github/workflows/upload-develop-preview.yml
@@ -30,11 +30,13 @@ jobs:
         with:
           ruby-version: '3.0'
           bundler-cache: true
+          cache-version: 0 # Increment this number if you need to re-download cached gems
 
       - name: ⬢ Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: '16'
+          cache: 'npm'
 
       - name: ⚙️ Install dependencies
         run: |

--- a/.github/workflows/upload-develop-preview.yml
+++ b/.github/workflows/upload-develop-preview.yml
@@ -52,8 +52,8 @@ jobs:
       - name: 👷‍♀️ Build the rest of the Primer Spec site
         uses: seshrs/build-primer-spec-action@main # TODO: Change this to v1 after releasing the new version of build-primer-spec-action
         with:
-          build_jekyll_site: false
-          configure_github_pages: false
+          build_jekyll_site: 'false'
+          configure_github_pages: 'false'
 
       # Upload the site to Primer Spec Preview and comment on the PR.
       # The Primer Spec Preview secret is stored as an encrypted repo or

--- a/.github/workflows/upload-develop-preview.yml
+++ b/.github/workflows/upload-develop-preview.yml
@@ -47,6 +47,14 @@ jobs:
           sed -i "\$ s/\$/ (develop preview build: $(date '+%Y-%m-%d') ($(git rev-parse HEAD)))/" VERSION
           ./script/ci-site-preview-build "https://preview.sesh.rs" "/previews/$REPO/develop-preview"
 
+      # Use `build-primer-spec-action` to generate PDFs of each page.
+      # Docs: https://github.com/seshrs/build-primer-spec-action
+      - name: 👷‍♀️ Build the rest of the Primer Spec site
+        uses: seshrs/build-primer-spec-action@main # TODO: Change this to v1 after releasing the new version of build-primer-spec-action
+        with:
+          build_jekyll_site: false
+          configure_github_pages: false
+
       # Upload the site to Primer Spec Preview and comment on the PR.
       # The Primer Spec Preview secret is stored as an encrypted repo or
       # organization secret named `PRIMER_SPEC_PREVIEW_SECRET`.

--- a/.github/workflows/upload-pr-preview.yml
+++ b/.github/workflows/upload-pr-preview.yml
@@ -42,6 +42,14 @@ jobs:
           sed -i "\$ s/\$/ (PR preview build: $(date '+%Y-%m-%d'))/" VERSION
           ./script/ci-site-preview-build "https://preview.sesh.rs" "/previews/$REPO/$PR_NUMBER"
 
+      # Use `build-primer-spec-action` to generate PDFs of each page.
+      # Docs: https://github.com/seshrs/build-primer-spec-action
+      - name: 👷‍♀️ Build the rest of the Primer Spec site
+        uses: seshrs/build-primer-spec-action@main # TODO: Change this to v1 after releasing the new version of build-primer-spec-action
+        with:
+          build_jekyll_site: false
+          configure_github_pages: false
+
       # Upload the site to Primer Spec Preview and comment on the PR.
       # The Primer Spec Preview secret is stored as an encrypted repo or
       # organization secret named `PRIMER_SPEC_PREVIEW_SECRET`.

--- a/.github/workflows/upload-pr-preview.yml
+++ b/.github/workflows/upload-pr-preview.yml
@@ -24,11 +24,13 @@ jobs:
         with:
           ruby-version: '3.0'
           bundler-cache: true
+          cache-version: 0 # Increment this number if you need to re-download cached gems
 
       - name: ⬢ Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: '16'
+          cache: 'npm'
 
       - name: ⚙️ Install dependencies
         run: |
@@ -47,8 +49,8 @@ jobs:
       - name: 👷‍♀️ Build the rest of the Primer Spec site
         uses: seshrs/build-primer-spec-action@main # TODO: Change this to v1 after releasing the new version of build-primer-spec-action
         with:
-          build_jekyll_site: false
-          configure_github_pages: false
+          build_jekyll_site: 'false'
+          configure_github_pages: 'false'
 
       # Upload the site to Primer Spec Preview and comment on the PR.
       # The Primer Spec Preview secret is stored as an encrypted repo or

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -57,6 +57,7 @@ version_string: v1.9
                     Do not change this code without also updating build-primer-spec-action.
                 {%- endcomment %}
                 pdfPath: null, // @managed by build-primer-spec-action
+                siteQualifiedBaseUrl: '{{ site.url }}{{ site.baseurl }}/',
                 hideSidebarOnLoad: {{ page.hideSidebarOnLoad | default: false }},
                 disableSidebar: {{ page.disableSidebar | default: false }},
                 defaultSubthemeName: '{{ site.primerSpec.defaultSubthemeName | default: "default" }}',

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -50,6 +50,13 @@ version_string: v1.9
         -->
         <script>
             window.PrimerSpecConfig = {
+                {%- comment -%}
+                    !! STOP !!
+                    The `pdfPath` flag is set by seshrs/build-primer-spec-action
+                    after the PDF for this page has been built.
+                    Do not change this code without also updating build-primer-spec-action.
+                {%- endcomment %}
+                pdfPath: null, // @managed by build-primer-spec-action
                 hideSidebarOnLoad: {{ page.hideSidebarOnLoad | default: false }},
                 disableSidebar: {{ page.disableSidebar | default: false }},
                 defaultSubthemeName: '{{ site.primerSpec.defaultSubthemeName | default: "default" }}',

--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -154,10 +154,18 @@ $INFO_BORDER_COLOR: rgba(4, 66, 137, 0.2);
   &-left {
     position: absolute;
     left: 1em;
+    .primer-spec-topbar-button {
+      display: inline;
+      padding-right: 2em;
+    }
   }
   &-right {
     position: absolute;
     right: 1em;
+    .primer-spec-topbar-button {
+      display: inline;
+      padding-left: 2em;
+    }
   }
 }
 

--- a/src_js/Config.ts
+++ b/src_js/Config.ts
@@ -25,7 +25,7 @@ export default {
   BUILD_MODE: process.env.BUILD_MODE,
 
   // From window.PrimerSpecConfig
-  PDF_PATH: window.PrimerSpecConfig.pdfPath || null,
+  PDF_PATH: window.PrimerSpecConfig.pdfPath || 'blah.pdf',
   SITE_QUALIFIED_BASE_URL: window.PrimerSpecConfig.siteQualifiedBaseUrl || '/',
   HIDE_SIDEBAR_ON_LOAD: getHideSidebarOnLoad(),
   DISABLE_SIDEBAR: window.PrimerSpecConfig.disableSidebar || false,

--- a/src_js/Config.ts
+++ b/src_js/Config.ts
@@ -25,7 +25,7 @@ export default {
   BUILD_MODE: process.env.BUILD_MODE,
 
   // From window.PrimerSpecConfig
-  PDF_PATH: window.PrimerSpecConfig.pdfPath || 'blah.pdf',
+  PDF_PATH: window.PrimerSpecConfig.pdfPath || null,
   SITE_QUALIFIED_BASE_URL: window.PrimerSpecConfig.siteQualifiedBaseUrl || '/',
   HIDE_SIDEBAR_ON_LOAD: getHideSidebarOnLoad(),
   DISABLE_SIDEBAR: window.PrimerSpecConfig.disableSidebar || false,

--- a/src_js/Config.ts
+++ b/src_js/Config.ts
@@ -25,6 +25,8 @@ export default {
   BUILD_MODE: process.env.BUILD_MODE,
 
   // From window.PrimerSpecConfig
+  PDF_PATH: window.PrimerSpecConfig.pdfPath || null,
+  SITE_QUALIFIED_BASE_URL: window.PrimerSpecConfig.siteQualifiedBaseUrl || '/',
   HIDE_SIDEBAR_ON_LOAD: getHideSidebarOnLoad(),
   DISABLE_SIDEBAR: window.PrimerSpecConfig.disableSidebar || false,
   INIT_SUBTHEME_NAME,

--- a/src_js/components/Topbar.tsx
+++ b/src_js/components/Topbar.tsx
@@ -2,7 +2,8 @@ import { h } from 'preact';
 import { useLayoutEffect, useRef } from 'preact/hooks';
 import clsx from 'clsx';
 import IconType from './common/IconType';
-import InlineButton from './common/InlineButton';
+import InlineButton, { InlineLinkButton } from './common/InlineButton';
+import Config from '../Config';
 
 type PropsType = {
   isSmallScreen: boolean;
@@ -35,7 +36,7 @@ export default function Topbar(props: PropsType): h.JSX.Element {
   let sidebar_toggle = null;
   if (props.showSidebarToggle) {
     sidebar_toggle = props.sidebarShown ? null : (
-      <div class={`primer-spec-sidebar-toggle-fixed primer-spec-float-left`}>
+      <div class={`primer-spec-topbar-button primer-spec-float-left`}>
         <InlineButton
           icon={IconType.SIDEBAR}
           onClick={props.onToggleSidebar}
@@ -45,10 +46,27 @@ export default function Topbar(props: PropsType): h.JSX.Element {
     );
   }
 
+  let downloadPdfButton = null;
+  if (!props.isSmallScreen && !props.settingsShown && Config.PDF_PATH != null) {
+    const href = Config.SITE_QUALIFIED_BASE_URL + Config.PDF_PATH;
+    downloadPdfButton = (
+      <div class="primer-spec-topbar-button">
+        <InlineLinkButton
+          icon={IconType.DOWNLOAD}
+          href={href}
+          download
+          ariaLabel={
+            props.settingsShown ? 'Close settings pane' : 'Open settings pane'
+          }
+        />
+      </div>
+    );
+  }
+
   let settings_toggle = null;
   if (props.showSettingsToggle) {
     settings_toggle = (
-      <div class="primer-spec-settings-toggle primer-spec-float-right">
+      <div class="primer-spec-topbar-button">
         <InlineButton
           icon={props.settingsShown ? IconType.CLOSE : IconType.SETTINGS}
           onClick={props.onToggleSettings}
@@ -78,7 +96,10 @@ export default function Topbar(props: PropsType): h.JSX.Element {
       )}
     >
       {sidebar_toggle}
-      {settings_toggle}
+      <div class="primer-spec-float-right">
+        {downloadPdfButton}
+        {settings_toggle}
+      </div>
     </header>
   );
 }

--- a/src_js/components/Topbar.tsx
+++ b/src_js/components/Topbar.tsx
@@ -47,7 +47,10 @@ export default function Topbar(props: PropsType): h.JSX.Element {
   }
 
   let downloadPdfButton = null;
-  if (!props.isSmallScreen && !props.settingsShown && Config.PDF_PATH != null) {
+  if (
+    Config.PDF_PATH != null &&
+    (!props.isSmallScreen || (props.isSmallScreen && props.settingsShown))
+  ) {
     const href = Config.SITE_QUALIFIED_BASE_URL + Config.PDF_PATH;
     downloadPdfButton = (
       <div class="primer-spec-topbar-button">

--- a/src_js/components/Topbar.tsx
+++ b/src_js/components/Topbar.tsx
@@ -55,9 +55,7 @@ export default function Topbar(props: PropsType): h.JSX.Element {
           icon={IconType.DOWNLOAD}
           href={href}
           download
-          ariaLabel={
-            props.settingsShown ? 'Close settings pane' : 'Open settings pane'
-          }
+          ariaLabel="Download PDF version of this page"
         />
       </div>
     );

--- a/src_js/components/Topbar.tsx
+++ b/src_js/components/Topbar.tsx
@@ -55,7 +55,7 @@ export default function Topbar(props: PropsType): h.JSX.Element {
           icon={IconType.DOWNLOAD}
           href={href}
           download
-          ariaLabel="Download PDF version of this page"
+          ariaLabel="Download this page as a PDF file"
         />
       </div>
     );

--- a/src_js/components/common/IconType.ts
+++ b/src_js/components/common/IconType.ts
@@ -4,5 +4,6 @@ enum IconType {
   SETTINGS = 'fas fa-cog',
   SIDEBAR = 'fas fa-bars',
   EXTERNAL_LINK = 'fas fa-external-link-alt',
+  DOWNLOAD = 'fas fa-file-download',
 }
 export default IconType;

--- a/src_js/components/common/InlineButton.tsx
+++ b/src_js/components/common/InlineButton.tsx
@@ -47,7 +47,7 @@ export function InlineLinkButton(
   return (
     <Hoverable floatRight={props.floatRight}>
       <a
-        class="btn-link primer-spec-hoverable no-print"
+        class="btn-link primer-spec-hoverable no-print tooltipped tooltipped-no-delay tooltipped-w"
         role="button"
         href={props.href}
         onClick={(event) => {

--- a/src_js/components/common/InlineButton.tsx
+++ b/src_js/components/common/InlineButton.tsx
@@ -1,15 +1,18 @@
 import { h } from 'preact';
 import IconType from './IconType';
 import { Hoverable } from './Hoverable';
+import { openExternalLink } from './openExternalLink';
 
-export type PropsType = {
+export type InlineButtonPropsType = {
   icon: IconType;
   floatRight?: boolean;
   onClick?: () => void;
   ariaLabel?: string;
 };
 
-export default function InlineButton(props: PropsType): h.JSX.Element {
+export default function InlineButton(
+  props: InlineButtonPropsType,
+): h.JSX.Element {
   return (
     <Hoverable floatRight={props.floatRight}>
       <button
@@ -26,6 +29,35 @@ export default function InlineButton(props: PropsType): h.JSX.Element {
       >
         <i class={props.icon} />
       </button>
+    </Hoverable>
+  );
+}
+
+export type InlineLinkButtonPropsType = {
+  icon: IconType;
+  floatRight?: boolean;
+  href: string;
+  download?: string | boolean;
+  ariaLabel?: string;
+};
+
+export function InlineLinkButton(
+  props: InlineLinkButtonPropsType,
+): h.JSX.Element {
+  return (
+    <Hoverable floatRight={props.floatRight}>
+      <a
+        class="btn-link primer-spec-hoverable no-print"
+        role="button"
+        href={props.href}
+        onClick={(event) => {
+          event.preventDefault();
+          openExternalLink({ url: props.href, download: props.download });
+        }}
+        aria-label={props.ariaLabel}
+      >
+        <i class={props.icon} />
+      </a>
     </Hoverable>
   );
 }

--- a/src_js/components/common/openExternalLink.ts
+++ b/src_js/components/common/openExternalLink.ts
@@ -1,0 +1,35 @@
+export function openExternalLink(props: {
+  url: string;
+  download?: string | boolean;
+}): void {
+  const { url, download } = props;
+
+  try {
+    sanityCheckUrl(url);
+  } catch (e) {
+    console.error('Blocking attempt to open external link. Error:', e);
+    return;
+  }
+
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  if (download != null && download !== false) {
+    // Use the original filename by not specifying one here.
+    anchor.download = typeof download === 'boolean' ? '' : download;
+  }
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  setTimeout(
+    () => {
+      document.body.removeChild(anchor);
+    },
+    2000, // 2 seconds
+  );
+}
+
+function sanityCheckUrl(url: string): void {
+  if (!url.startsWith('https://') && !url.startsWith('/')) {
+    throw new Error(`Expected HTTPS external link, received: ${url}`);
+  }
+}

--- a/src_js/global.d.ts
+++ b/src_js/global.d.ts
@@ -1,6 +1,8 @@
 // Need to declare that the window object may have a PrimerSpecConfig.
 // eslint-disable-next-line no-var
 declare var PrimerSpecConfig: {
+  pdfPath?: string | null;
+  siteQualifiedBaseUrl?: string;
   hideSidebarOnLoad?: boolean;
   disableSidebar?: boolean;
   defaultSubthemeName?: string;


### PR DESCRIPTION
## Context

Closes #136! 🚀
As mentioned in #136, I've seen Piazza questions with students asking how to download the spec as a PDF (either because they don't know about print-to-PDF, or because they assume that the PDF won't look good). Hence, let's make the PDF version of the page easily available!

This turned out to be a complex feature, and [was only recently made possible by GitHub Pages + GitHub Actions + GitHub Support](https://github.com/eecs485staff/primer-spec/issues/136#issuecomment-1287647294).

## NOTE: "Download as PDF" feature only works when site is built with [`build-primer-spec-action`](https://github.com/seshrs/build-primer-spec-action)

If you're a course instructor, and your course website does not yet use [`build-primer-spec-action`](https://github.com/seshrs/build-primer-spec-action), your website's pages will not show the "Download as PDF" button.

Follow the instructions in that action's [README](https://github.com/seshrs/build-primer-spec-action#setting-up-github-pages-deployment) to set up GitHub Pages deployment via the action!

## Validation

Visit one of the pages in the PR preview website. If you click the "download" button, your browser will download the PDF version of the page! Example page: https://preview.sesh.rs/previews/eecs485staff/primer-spec/225/docs/USAGE_ADVANCED.html

<img width="1000" alt="Screen Shot 2022-11-28 at 11 20 46 PM" src="https://user-images.githubusercontent.com/12139762/204464391-d8534681-2c80-4459-a825-4ae1de504268.png">

<sup>Known issue: Some of the pages are not rendered correctly. I'm <em>pretty</em> sure this is related to my repo setup and will not happen on real spec websites, but I'll need to keep an eye out for this after this PR merges.</sup>
