### PR TITLE
[PDF] Fix tooltip styling in dark mode

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -805,11 +805,23 @@ div.primer-spec-callout {
   }
 }
 
-.tooltipped:hover,
-.tooltipped:focus {
+.tooltipped-n:hover,
+.tooltipped-n:focus {
   &::before {
     color: var(--tooltip-background-color);
     border-top-color: var(--tooltip-background-color);
+  }
+  &::after {
+    color: var(--tooltip-color);
+    background-color: var(--tooltip-background-color);
+    border-color: var(--tooltip-background-color);
+  }
+}
+.tooltipped-w:hover,
+.tooltipped-w:focus {
+  &::before {
+    color: var(--tooltip-background-color);
+    border-left-color: var(--tooltip-background-color);
   }
   &::after {
     color: var(--tooltip-color);


### PR DESCRIPTION
In #225, I was initially unsure why the tooltip was incorrectly styled. I discovered that the issue was because of conflicting styles with the "Copy" button from Enhanced Code blocks.

This PR fixes the styles to differentiate between the [different tooltip positions supported by Primer CSS](https://primer.style/css/components/tooltips).

<table>
<tr>
<th></th>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>Light mode</td>
<td>
<img width="241" alt="image" src="https://user-images.githubusercontent.com/12139762/209403669-4a622177-e413-4691-8669-f1bf87b33273.png">
</td>
<td>
<img width="240" alt="image" src="https://user-images.githubusercontent.com/12139762/209403696-78b2bd0c-3669-4644-8854-c4b670cd1320.png">
</td>
</tr>
<tr>
<td>Dark mode</td>
<td>
<img width="238" alt="image" src="https://user-images.githubusercontent.com/12139762/209403794-b715aebc-4b28-47cd-ae46-1dff3a981fd7.png">

</td>
<td>
<img width="242" alt="image" src="https://user-images.githubusercontent.com/12139762/209403761-936fefe3-4e33-4690-91d2-fe401b57a99a.png">

</td>
</tr>
</table>