### PR TITLE
[PDF] Wrap long codeblock lines in print previews

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -28,6 +28,21 @@ $INFO_BORDER_COLOR: rgba(4, 66, 137, 0.2);
   .no-print * {
     display: none !important;
   }
+
+  // Enable line-wrapping for code blocks (instead of clipping and showing
+  // scrollbars.
+  pre,
+  pre > code {
+    overflow: visible !important;
+    white-space: pre-wrap !important;
+    word-wrap: break-all !important;
+  }
+
+  .primer-spec-code-block table.highlight td.primer-spec-code-block-line-code {
+    overflow: visible !important;
+    white-space: pre-wrap !important;
+    word-wrap: break-all !important;
+  }
 }
 
 /* Sidebar */


### PR DESCRIPTION
Fixes #227.

I visited PREVIEW#232, navigated to the Markdown Tips document and viewed the generated PDF.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="914" alt="Screen Shot 2022-12-23 at 4 12 45 PM" src="https://user-images.githubusercontent.com/12139762/209406012-4928e87c-0490-4554-b738-c9d41b5d66cc.png">
</td>
<td><img width="914" alt="Screen Shot 2022-12-23 at 4 12 49 PM" src="https://user-images.githubusercontent.com/12139762/209405998-0e716a05-7e05-4c31-94fe-f1bfdfe5f44a.png"></td>
</tr>
</table>