### PR TITLE
[Enhanced code blocks] Insert newline at the end of copied multi-line text

### DIFF
--- a/src_js/components/main_content/enhanced_code_blocks/genCopyButton.tsx
+++ b/src_js/components/main_content/enhanced_code_blocks/genCopyButton.tsx
@@ -102,6 +102,6 @@ async function copyLines(
   const linesOfText = [...lines]
     .map((line) => mapFn(line))
     .filter((lineText) => lineText != null);
-  const text = linesOfText.join('\n');
+  const text = `${linesOfText.join('\n')}\n`;
   await navigator.clipboard.writeText(text);
 }


### PR DESCRIPTION
## Context

Closes #223. Thanks @awdeorio and @ohjuny, this was a great suggestion 😃 

## Validation

Visit the preview URL and try copying any of the multiline code blocks (including console blocks). A newline is appended to the copied text.

https://preview.sesh.rs/previews/eecs485staff/primer-spec/234/demo/enhanced-code-blocks.html