### PR TITLE
[Enhanced Code Blocks] Use full width in no-line-numbers variant

### DIFF
--- a/_sass/spec/base.scss
+++ b/_sass/spec/base.scss
@@ -767,6 +767,7 @@ div.primer-spec-callout {
     }
 
     td.primer-spec-code-block-line-number {
+      width: 1%;
       cursor: pointer;
       -webkit-user-select: none;
       -moz-user-select: none;
@@ -774,7 +775,6 @@ div.primer-spec-callout {
       user-select: none;
 
       &.primer-spec-code-block-line-numbers-shown {
-        width: 1%;
         min-width: 50px;
         color: var(--code-block-line-number-color);
         text-align: right;

--- a/demo/enhanced-code-blocks.md
+++ b/demo/enhanced-code-blocks.md
@@ -511,7 +511,7 @@ The water was warm. There was plenty to eat.
 The turtles had everything turtles might need.
 And they were all happy. Quite happy indeed.
 ```
-{: data-variant="no-line-numbers" }
+{: data-variant="no-line-numbers" data-highlight="2" }
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
@@ -527,7 +527,7 @@ The water was warm. There was plenty to eat.
 The turtles had everything turtles might need.
 And they were all happy. Quite happy indeed.
 ```
-{: data-variant="no-line-numbers" }
+{: data-variant="no-line-numbers" data-highlight="2" }
 ````
   {: data-highlight="9" data-title="markdown" }
 </details>


### PR DESCRIPTION
## Context

Closes #235. Honestly, I'm not yet certain why the `width` CSS property behaves like this, but I suspect that simply setting a percentage width on a child changes how the parent's width is calculated.

## Validation

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="1009" alt="Screen Shot 2022-12-25 at 11 56 09 AM" src="https://user-images.githubusercontent.com/12139762/209476297-0747ab09-246d-49e2-bb47-7b0f36236da8.png">
</td>
<td>
<img width="1009" alt="Screen Shot 2022-12-25 at 11 55 49 AM" src="https://user-images.githubusercontent.com/12139762/209476292-4fc4b0bd-887b-4c71-a042-3d674f001ff3.png">
</td>
</tr>
</table>