### PR TITLE
[Enhanced Code Blocks] Avoid showing line numbers on single-line codeblocks

### DIFF
--- a/demo/enhanced-code-blocks.md
+++ b/demo/enhanced-code-blocks.md
@@ -533,6 +533,51 @@ And they were all happy. Quite happy indeed.
 </details>
 <!-- prettier-ignore-end -->
 
+<div class="primer-spec-callout info" markdown="1">
+If an `enhanced` codeblock has just one line, we will automatically hide line numbers. For example:
+
+<!-- prettier-ignore-start -->
+```plaintext
+This codeblock has just one line, so we won't show line numbers.
+```
+{: .debug }
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+<details markdown="1">
+  <summary>Source code for this single-line code block</summary>
+  
+  ````markdown
+```plaintext
+This codeblock has just one line, so we won't show line numbers.
+```
+  ````
+</details>
+<!-- prettier-ignore-end -->
+
+If you <em>really</em> want to show line numbers, then specify the variant explicitly on the code block:
+
+<!-- prettier-ignore-start -->
+```plaintext
+Even though this codeblock has just one line, we show line numbers because we specified the 'enhanced' variant.
+```
+{: data-variant="enhanced" }
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+<details markdown="1">
+  <summary>Source code for this single-line code block <em>with line numbers</em></summary>
+  
+  ````markdown
+```plaintext
+Even though this codeblock has just one line, we show line numbers because we specified the 'enhanced' variant.
+```
+{: data-variant="enhanced" }
+  ````
+</details>
+<!-- prettier-ignore-end -->
+</div>
+
 ### `legacy`
 
 This is the original style of code blocks from the original [GitHub Primer theme](https://github.com/pages-themes/primer).

--- a/src_js/components/main_content/enhanced_code_blocks/useEnhancedCodeBlocks.tsx
+++ b/src_js/components/main_content/enhanced_code_blocks/useEnhancedCodeBlocks.tsx
@@ -151,7 +151,8 @@ function enhanceBlocks(
         title,
         anchorId,
         showLineNumbers:
-          getCodeblockVariant(codeblock) !== CodeblockVariant.NO_LINE_NUMBERS,
+          getCodeblockVariant(codeblock, codeblockContents) !==
+          CodeblockVariant.NO_LINE_NUMBERS,
       });
       if (!enhancedCodeBlock) {
         return;
@@ -180,13 +181,33 @@ function shouldRetainLegacyCodeBlock(codeblock: HTMLElement): boolean {
   return getCodeblockVariant(codeblock) === CodeblockVariant.LEGACY;
 }
 
-function getCodeblockVariant(codeblock: HTMLElement): CodeblockVariant {
+function getCodeblockVariant(
+  codeblock: HTMLElement,
+  rawContent?: string,
+): CodeblockVariant {
   const rawVariant = codeblock.dataset[
     'variant'
   ]?.toLowerCase() as CodeblockVariant | null;
   if (rawVariant && Object.values(CodeblockVariant).includes(rawVariant)) {
     return rawVariant as CodeblockVariant;
   }
+
+  // Special handling if:
+  // - A codeblock does not specify a variant
+  // - The default code block variant is "enhanced" (aka show line numbers)
+  // - The codeblock has only one line
+  // Then DO NOT show line numbers. I've come to believe that line numbers
+  // look confusing in single-line codeblocks.
+  const codeblockHasOnlyOneLine = rawContent
+    ? !rawContent.trim().includes('\n')
+    : false;
+  if (
+    Config.DEFAULT_CODEBLOCK_VARIANT === CodeblockVariant.ENHANCED &&
+    codeblockHasOnlyOneLine
+  ) {
+    return CodeblockVariant.NO_LINE_NUMBERS;
+  }
+
   return Config.DEFAULT_CODEBLOCK_VARIANT;
 }
 


### PR DESCRIPTION
## Context

While browsing EECS 183's Project 1 spec, I noticed that they use single line codeblocks extensively. The line numbers look confusing! See [this section](https://eecs183.github.io/p1-recipes/#ingredient-cost-and-conversions) for example:

> <img width="1057" alt="image" src="https://user-images.githubusercontent.com/12139762/213884965-bf17bbb4-bc8b-4ab8-9d5d-15a1cde5319f.png">

This PR changes the behavior of enhanced code blocks so that _by default_, single-line codeblocks will not show line numbers.

## Validation

Visit https://preview.sesh.rs/previews/eecs485staff/primer-spec/244/demo/enhanced-code-blocks.html#no-line-numbers and observe the single line codeblocks in the info callout.

> <img width="1058" alt="image" src="https://user-images.githubusercontent.com/12139762/213885034-8de58fd0-a52d-4977-8e09-f2f6fdcf99db.png">
