### PR TITLE
Add ENGR 100 class to user showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ You may also want to read the [`MARKDOWN_TIPS`](https://eecs485staff.github.io/p
 
 The Primer Spec theme is currently used by the following courses at the University of Michigan:
 
+- [ENGR 100](https://980.engr100.org) (Introduction to Engineering). Example [ENGR 100-980 Lab 1: Arduino 101](https://980.engr100.org/labs/lab-1).
 - [EECS 280](https://eecs280staff.github.io/eecs280.org/) (Programming and Intro Data Structures). Example [EECS 280 Project 4: Web](https://eecs280staff.github.io/p4-web/).
 - [EECS 281](https://eecs281staff.github.io/eecs281.org/) (Data Structures and Algorithms). Example [EECS 281 Project 1: Back to the Ship!](https://eecs281staff.github.io/p1-back-to-the-ship/).
 - [EECS 285](https://eecs285.github.io/eecs285.org/) (Practical Programming in Java). Example [EECS 285 Project 3: Wheel of Fortune](https://eecs285.github.io/p3-wheel/).


### PR DESCRIPTION
ENGR 100 class section 980 - Rocket Science now uses primer spec on its own website. 

I am also working on creating the labs and site for section 950 and will turn engr100.org into a landing page once completed. The hope is that other ENGR 100 sections can use our github org to add their own sections to our website.