### PR TITLE
Pin to Mermaid v9

### DIFF
--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -40,7 +40,7 @@ version_string: v1.10
                 font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji" !important;
             }
         </style>
-        <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js" crossorigin="anonymous" defer></script>
+        <script src="https://cdn.jsdelivr.net/npm/mermaid@9/dist/mermaid.min.js" crossorigin="anonymous" defer></script>
         {%- endif %}
 
         <!--


### PR DESCRIPTION
## Context

Closes eecs280staff/p5-ml#183.

@amirkamil noticed that Mermaid diagrams weren't rendering on the P5 spec:

| Expected|Actual|
|--|--|
|<img width="1046" alt="Screenshot 2023-11-06 at 8 15 52 PM" src="https://github.com/eecs280staff/p5-ml/assets/2025676/55c3ea09-3c30-4702-909f-46f959e6d3bf"> | <img width="1021" alt="Screenshot 2023-11-06 at 8 14 11 PM" src="https://github.com/eecs280staff/p5-ml/assets/2025676/210e4a1e-c3b6-48f7-a0d4-59476e4174bd"> |

Digging a bit, I found https://github.com/mermaid-js/mermaid/issues/4442, which noted that the root cause was a breaking change in [v10 of MermaidJS](https://github.com/mermaid-js/mermaid/releases/tag/v10.0.0):
> Mermaid is ESM only!

I didn't notice when adding MermaidJS support to Primer Spec, but it turned out that the documentation had let me to always use the latest version of MermaidJS instead of pinning to a specific version — hence, we were exposed to the breaking change :(

## In this PR

This commit changes the Primer Spec to always use MermaidJS v9, which is compatible with CJS and exposes the global variable `mermaid`.

In future, it would make sense to follow-up how best to upgrade to Mermaid v10. But this works for now.

## Validation

Visit the preview URL's ["Diagrams" demo](https://preview.sesh.rs/previews/eecs485staff/primer-spec/254/demo/diagrams.html#flowcharts). Notice that the Mermaid diagrams now render again.