### PR TITLE
Fixes #270: Add a customizable section to spec document head

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -1,0 +1,6 @@
+{% comment %}
+
+Any uncommented code in this file will be included just before the end of
+the document head.
+
+{% endcomment %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
       <link rel="icon" href="{{ site.favicon | relative_url }}">
       {%- endif %}
     <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    {% include custom-head.html %}
   </head>
   <body>
     <div class="container-lg px-3 my-5 markdown-body">

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -167,6 +167,7 @@ version_string: v1.10
         </style>
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" id="MathJax-script" defer></script>
         {%- endif %}
+        {% include custom-head.html %}
     </head>
     <body>
         <div id="primer-spec-top"></div>


### PR DESCRIPTION
This will allow local customizations of the <head> without the need to override the entire spec layout. A file is added to _includes named custom-head.html and its contents are included before the close tag of the document head.